### PR TITLE
feat: Auth 연동을 위한 Member 최소 기능 추가 #13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/jpa.yml

--- a/src/main/java/com/runky/member/domain/ExternalAccount.java
+++ b/src/main/java/com/runky/member/domain/ExternalAccount.java
@@ -1,0 +1,52 @@
+package com.runky.member.domain;
+
+import org.hibernate.annotations.Comment;
+
+import com.runky.member.domain.exception.InvalidExternalAccountException;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExternalAccount {
+
+	@Comment("카카오 등 외부 provider 이름 ex. kakao")
+	@Column(name = "provider", nullable = false, length = 32)
+	private String provider;
+
+	@Comment("카카오 등 외부 provider 식별자")
+	@Column(name = "provider_id", nullable = false, length = 64)
+	private String providerId;
+
+	private ExternalAccount(String provider, String providerId) {
+		
+		if (provider == null || provider.isBlank())
+			throw new InvalidExternalAccountException();
+		if (providerId == null || providerId.isBlank())
+			throw new InvalidExternalAccountException();
+
+		provider = provider.trim().toLowerCase();
+		providerId = providerId.trim();
+
+		if (providerId.length() > 64)
+			throw new InvalidExternalAccountException();
+
+		this.provider = provider;
+		this.providerId = providerId;
+	}
+
+	public static ExternalAccount of(String provider, String providerId) {
+		return new ExternalAccount(provider, providerId);
+	}
+
+	public String provider() {
+		return provider;
+	}
+
+	public String providerId() {
+		return providerId;
+	}
+}

--- a/src/main/java/com/runky/member/domain/Member.java
+++ b/src/main/java/com/runky/member/domain/Member.java
@@ -1,0 +1,56 @@
+package com.runky.member.domain;
+
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+	name = "member",
+	uniqueConstraints = @UniqueConstraint(
+		name = "uk_member_provider_provider_id",
+		columnNames = {"provider", "provider_id"}
+	),
+	indexes = @Index(name = "ix_member_provider_provider_id", columnList = "provider,provider_id")
+)
+public class Member {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Embedded
+	private ExternalAccount externalAccount;
+
+	@Enumerated(EnumType.STRING)
+	private MemberRole role;
+	private String nickname;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private Member(Long id, ExternalAccount externalAccount, MemberRole role, String nickname) {
+		this.id = id;
+		this.externalAccount = externalAccount;
+		this.role = role;
+		this.nickname = nickname;
+	}
+
+	public static Member register(ExternalAccount account, String nickname) {
+		return Member.builder()
+			.externalAccount(account)
+			.role(MemberRole.USER)
+			.nickname(nickname)
+			.build();
+	}
+}

--- a/src/main/java/com/runky/member/domain/MemberRole.java
+++ b/src/main/java/com/runky/member/domain/MemberRole.java
@@ -1,0 +1,5 @@
+package com.runky.member.domain;
+
+public enum MemberRole {
+	USER, ADMIN
+}

--- a/src/main/java/com/runky/member/domain/dto/MemberCommand.java
+++ b/src/main/java/com/runky/member/domain/dto/MemberCommand.java
@@ -1,0 +1,7 @@
+package com.runky.member.domain.dto;
+
+public sealed interface MemberCommand {
+
+	record RegisterFromExternal(String provider, String providerId, String nickname) implements MemberCommand {
+	}
+}

--- a/src/main/java/com/runky/member/domain/dto/MemberInfo.java
+++ b/src/main/java/com/runky/member/domain/dto/MemberInfo.java
@@ -1,0 +1,9 @@
+package com.runky.member.domain.dto;
+
+import com.runky.member.domain.MemberRole;
+
+public sealed interface MemberInfo {
+
+	record Summary(Long id, MemberRole role, String nickname) implements MemberInfo {
+	}
+}

--- a/src/main/java/com/runky/member/domain/exception/DuplicateMemberException.java
+++ b/src/main/java/com/runky/member/domain/exception/DuplicateMemberException.java
@@ -1,0 +1,9 @@
+package com.runky.member.domain.exception;
+
+import com.runky.global.error.GlobalException;
+
+public class DuplicateMemberException extends GlobalException {
+	public DuplicateMemberException() {
+		super(MemberErrorCode.DUPLICATE_MEMBER);
+	}
+}

--- a/src/main/java/com/runky/member/domain/exception/InvalidExternalAccountException.java
+++ b/src/main/java/com/runky/member/domain/exception/InvalidExternalAccountException.java
@@ -1,0 +1,9 @@
+package com.runky.member.domain.exception;
+
+import com.runky.global.error.GlobalException;
+
+public class InvalidExternalAccountException extends GlobalException {
+	public InvalidExternalAccountException() {
+		super(MemberErrorCode.INVALID_EXTERNAL_ACCOUNT);
+	}
+}

--- a/src/main/java/com/runky/member/domain/exception/MemberErrorCode.java
+++ b/src/main/java/com/runky/member/domain/exception/MemberErrorCode.java
@@ -1,0 +1,23 @@
+package com.runky.member.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.runky.global.error.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-404-01", "회원이 존재하지 않습니다."),
+
+	INVALID_EXTERNAL_ACCOUNT(HttpStatus.BAD_REQUEST, "MEMBER-400-01", "외부 계정 정보가 올바르지 않습니다."),
+
+	DUPLICATE_MEMBER(HttpStatus.CONFLICT, "MEMBER-409-01", "이미 가입된 회원입니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/runky/member/domain/exception/MemberNotFoundException.java
+++ b/src/main/java/com/runky/member/domain/exception/MemberNotFoundException.java
@@ -1,0 +1,9 @@
+package com.runky.member.domain.exception;
+
+import com.runky.global.error.GlobalException;
+
+public class MemberNotFoundException extends GlobalException {
+	public MemberNotFoundException() {
+		super(MemberErrorCode.MEMBER_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/runky/member/domain/port/MemberRepository.java
+++ b/src/main/java/com/runky/member/domain/port/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.runky.member.domain.port;
+
+import java.util.Optional;
+
+import com.runky.member.domain.Member;
+
+public interface MemberRepository {
+	boolean existsByExternalAccountProviderAndExternalAccountProviderId(String provider, String s);
+
+	Optional<Member> findByExternalAccountProviderAndExternalAccountProviderId(String provider, String providerId);
+
+	Member saveAndFlush(Member member);
+
+}

--- a/src/main/java/com/runky/member/domain/service/MemberReader.java
+++ b/src/main/java/com/runky/member/domain/service/MemberReader.java
@@ -1,0 +1,27 @@
+package com.runky.member.domain.service;
+
+import org.springframework.stereotype.Component;
+
+import com.runky.member.domain.Member;
+import com.runky.member.domain.dto.MemberInfo;
+import com.runky.member.domain.exception.MemberNotFoundException;
+import com.runky.member.domain.port.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberReader {
+	private final MemberRepository memberRepository;
+
+	public boolean existsByExternalAccount(String provider, String providerId) {
+		return memberRepository.existsByExternalAccountProviderAndExternalAccountProviderId(provider, providerId);
+	}
+
+	public MemberInfo.Summary getInfoByExternalAccount(String provider, String providerId) {
+		Member member = memberRepository.findByExternalAccountProviderAndExternalAccountProviderId(provider, providerId)
+			.orElseThrow(MemberNotFoundException::new);
+
+		return new MemberInfo.Summary(member.getId(), member.getRole(), member.getNickname());
+	}
+}

--- a/src/main/java/com/runky/member/domain/service/MemberRegistrar.java
+++ b/src/main/java/com/runky/member/domain/service/MemberRegistrar.java
@@ -1,0 +1,46 @@
+package com.runky.member.domain.service;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+import com.runky.member.domain.ExternalAccount;
+import com.runky.member.domain.Member;
+import com.runky.member.domain.dto.MemberCommand;
+import com.runky.member.domain.dto.MemberInfo;
+import com.runky.member.domain.exception.DuplicateMemberException;
+import com.runky.member.domain.exception.MemberNotFoundException;
+import com.runky.member.domain.port.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MemberRegistrar {
+	private final MemberRepository memberRepository;
+
+	public MemberInfo.Summary registerFromExternal(MemberCommand.RegisterFromExternal command) {
+		ExternalAccount account = ExternalAccount.of(command.provider(), command.providerId());
+		String nickname = command.nickname();
+
+		if (memberRepository.existsByExternalAccountProviderAndExternalAccountProviderId(
+			account.provider(),
+			account.providerId())
+		) {
+			Member existing = memberRepository.findByExternalAccountProviderAndExternalAccountProviderId(
+				account.provider(), account.providerId()).orElseThrow(MemberNotFoundException::new);
+			return new MemberInfo.Summary(existing.getId(), existing.getRole(), existing.getNickname());
+		}
+
+		Member member = Member.register(account, nickname);
+		try {
+			Member saved = memberRepository.saveAndFlush(member);
+			return new MemberInfo.Summary(saved.getId(), saved.getRole(), saved.getNickname());
+		} catch (DataIntegrityViolationException e) {
+			Member merged = memberRepository.findByExternalAccountProviderAndExternalAccountProviderId(
+				account.provider(), account.providerId()
+			).orElseThrow(DuplicateMemberException::new);
+			return new MemberInfo.Summary(merged.getId(), merged.getRole(), merged.getNickname());
+		}
+
+	}
+}

--- a/src/main/java/com/runky/member/infrastructure/persistence/JpaMemberRepository.java
+++ b/src/main/java/com/runky/member/infrastructure/persistence/JpaMemberRepository.java
@@ -1,0 +1,13 @@
+package com.runky.member.infrastructure.persistence;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.runky.member.domain.Member;
+
+public interface JpaMemberRepository extends JpaRepository<Member, Long> {
+	Optional<Member> findByExternalAccountProviderAndExternalAccountProviderId(String provider, String providerId);
+
+	boolean existsByExternalAccountProviderAndExternalAccountProviderId(String provider, String providerId);
+}

--- a/src/main/java/com/runky/member/infrastructure/persistence/MemberRepositoryImpl.java
+++ b/src/main/java/com/runky/member/infrastructure/persistence/MemberRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.runky.member.infrastructure.persistence;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.runky.member.domain.Member;
+import com.runky.member.domain.port.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepository {
+	private final JpaMemberRepository jpa;
+
+	@Override
+	public Optional<Member> findByExternalAccountProviderAndExternalAccountProviderId(String provider,
+		String providerId) {
+		return jpa.findByExternalAccountProviderAndExternalAccountProviderId(provider, providerId);
+	}
+
+	@Override
+	public boolean existsByExternalAccountProviderAndExternalAccountProviderId(String provider, String providerId) {
+		return jpa.existsByExternalAccountProviderAndExternalAccountProviderId(provider, providerId);
+	}
+
+	@Override
+	public Member saveAndFlush(Member member) {
+		return jpa.saveAndFlush(member);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,24 @@
+kakao:
+  client:
+    id: 10591b4c28e1de84d6fd5da8ec5c3467
+    secret: P58Ag0P2sjaW2hlhtxNJn1WD2QJqZnD6
+  redirect-url: http://localhost:8080/api/auth/login/oauth2/code/kakao
+
+
+runky:
+  security:
+    cookie:
+      domain: localhost
+      secure: true
+      http-only: true
+      same-site: none
+    jwt:
+      secretKey: testSecretKey20230327testSecretKey20230327testSecretKey20230327
+      expirationTime:
+        accessTokenMinutes: 60
+        refreshTokenHours: 24
+      refresh-token:
+        pepper: refreshSecret20250812refreshSecret20250812refreshSecret20250812
 server:
   shutdown: graceful
   tomcat:
@@ -26,9 +47,9 @@ spring:
         format_sql: true
 
 springdoc:
-    use-fqn: true
-    swagger-ui:
-      path: /swagger-ui.html
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
 
 ---
 spring:

--- a/src/main/resources/jpa.yml
+++ b/src/main/resources/jpa.yml
@@ -45,8 +45,8 @@ datasource:
   mysql-jpa:
     main:
       jdbc-url: jdbc:mysql://localhost:3306/runky
-      username: application
-      password: application
+      username: root
+      password:
 
 
 ---


### PR DESCRIPTION
## 🌱 관련 이슈
- close #13

## 📌 작업 내용 및 특이사항
- Auth 기능 구현을 위한 최소  Member 기능을 구현했습니다.

## 📝 참고사항
- Domain Layer의 DTO는 생성자 생성을 막기 위해 sealed interface 타입으로 지정했습니다.
```java
public sealed interface MemberCommand { ...}
```
- Auth 관련 VO인 ExternalAccount'만' 검증 코드가 존재합니다. (기타 사진 참고)
- 테스트 코드 없습니다.
- 도메인에서 외부 의존성은 port 패키지 하위에 두었습니다. 

<img width="267" height="44" alt="image" src="https://github.com/user-attachments/assets/b963ac1f-860a-4cd9-8b7e-f12964759f66" />


## 📚 기타
<img width="546" height="636" alt="image" src="https://github.com/user-attachments/assets/5cf8814d-4ba3-4165-aaf0-5d6c757b1dbb" />

전체 패키지 구조
<img width="379" height="482" alt="image" src="https://github.com/user-attachments/assets/b4cf5e0c-5260-4b72-a9a7-5d8fa4cf4b59" />

