### PR TITLE
Feature: 크루 공통 기능 추가

### DIFF
--- a/src/main/java/com/runky/crew/api/CrewApiSpec.java
+++ b/src/main/java/com/runky/crew/api/CrewApiSpec.java
@@ -50,4 +50,13 @@ public interface CrewApiSpec {
             @Schema(name = "크루 ID", description = "탈퇴할 크루 ID") Long crewId,
             Long userId
     );
+
+    @Operation(
+            summary = "크루원 목록 조회",
+            description = "크루의 멤버를 조회합니다."
+    )
+    ApiResponse<CrewResponse.Members> getCrewMembers(
+            @Schema(name = "크루 ID", description = "멤버를 조회할 크루 ID") Long crewId,
+            Long userId
+    );
 }

--- a/src/main/java/com/runky/crew/api/CrewApiSpec.java
+++ b/src/main/java/com/runky/crew/api/CrewApiSpec.java
@@ -23,4 +23,12 @@ public interface CrewApiSpec {
     ApiResponse<CrewResponse.Join> joinCrew(
             @Schema(name = "크루 가입 요청", description = "크루 가입에 필요한 정보") CrewRequest.Join request, Long userId
     );
+
+    @Operation(
+            summary = "크루 목록 조회",
+            description = "사용자가 속한 크루 목록을 조회합니다."
+    )
+    ApiResponse<CrewResponse.Cards> getCrews(
+            Long userId
+    );
 }

--- a/src/main/java/com/runky/crew/api/CrewApiSpec.java
+++ b/src/main/java/com/runky/crew/api/CrewApiSpec.java
@@ -37,7 +37,17 @@ public interface CrewApiSpec {
             description = "크루의 상세 정보를 조회합니다."
     )
     ApiResponse<CrewResponse.Detail> getCrew(
-            Long crewId,
+            @Schema(name = "크루 ID", description = "상세 조회할 크루 ID") Long crewId,
+            Long userId
+    );
+
+    @Operation(
+            summary = "크루 탈퇴",
+            description = "크루에서 탈퇴합니다."
+    )
+    ApiResponse<CrewResponse.Leave> leaveCrew(
+            @Schema(name = "멤버 ID", description = "새 리더로 지정할 멤버 ID") CrewRequest.Leave request,
+            @Schema(name = "크루 ID", description = "탈퇴할 크루 ID") Long crewId,
             Long userId
     );
 }

--- a/src/main/java/com/runky/crew/api/CrewApiSpec.java
+++ b/src/main/java/com/runky/crew/api/CrewApiSpec.java
@@ -15,4 +15,12 @@ public interface CrewApiSpec {
     ApiResponse<CrewResponse.Create> createCrew(
             @Schema(name = "크루 생성 요청", description = "크루 생성에 필요한 정보") CrewRequest.Create request, Long userId
     );
+
+    @Operation(
+            summary = "크루 가입",
+            description = "크루에 가입합니다."
+    )
+    ApiResponse<CrewResponse.Join> joinCrew(
+            @Schema(name = "크루 가입 요청", description = "크루 가입에 필요한 정보") CrewRequest.Join request, Long userId
+    );
 }

--- a/src/main/java/com/runky/crew/api/CrewApiSpec.java
+++ b/src/main/java/com/runky/crew/api/CrewApiSpec.java
@@ -31,4 +31,13 @@ public interface CrewApiSpec {
     ApiResponse<CrewResponse.Cards> getCrews(
             Long userId
     );
+
+    @Operation(
+            summary = "크루 상세 조회",
+            description = "크루의 상세 정보를 조회합니다."
+    )
+    ApiResponse<CrewResponse.Detail> getCrew(
+            Long crewId,
+            Long userId
+    );
 }

--- a/src/main/java/com/runky/crew/api/CrewController.java
+++ b/src/main/java/com/runky/crew/api/CrewController.java
@@ -61,4 +61,15 @@ public class CrewController implements CrewApiSpec {
         CrewResult.Leave result = crewFacade.leaveCrew(new CrewCriteria.Leave(crewId, userId, request.newLeaderId()));
         return ApiResponse.success(CrewResponse.Leave.from(result));
     }
+
+    @Override
+    @GetMapping("/{crewId}/members")
+    public ApiResponse<CrewResponse.Members> getCrewMembers(@PathVariable Long crewId,
+                                                            @RequestHeader("X-USER-ID") Long userId) {
+        List<CrewResult.CrewMember> results = crewFacade.getCrewMembers(new CrewCriteria.Members(crewId, userId));
+        List<CrewResponse.Member> members = results.stream()
+                .map(CrewResponse.Member::from)
+                .toList();
+        return ApiResponse.success(new CrewResponse.Members(members));
+    }
 }

--- a/src/main/java/com/runky/crew/api/CrewController.java
+++ b/src/main/java/com/runky/crew/api/CrewController.java
@@ -1,6 +1,5 @@
 package com.runky.crew.api;
 
-import com.runky.crew.api.CrewResponse.Create;
 import com.runky.crew.application.CrewCriteria;
 import com.runky.crew.application.CrewFacade;
 import com.runky.crew.application.CrewResult;
@@ -21,8 +20,17 @@ public class CrewController implements CrewApiSpec {
 
     @Override
     @PostMapping
-    public ApiResponse<Create> createCrew(@Valid @RequestBody CrewRequest.Create request, @RequestHeader("X-USER-ID") Long userId) {
+    public ApiResponse<CrewResponse.Create> createCrew(@Valid @RequestBody CrewRequest.Create request,
+                                                       @RequestHeader("X-USER-ID") Long userId) {
         CrewResult result = crewFacade.create(new CrewCriteria.Create(userId, request.name()));
         return ApiResponse.success(CrewResponse.Create.from(result));
+    }
+
+    @Override
+    @PostMapping("/join")
+    public ApiResponse<CrewResponse.Join> joinCrew(@Valid @RequestBody CrewRequest.Join request,
+                                                   @RequestHeader("X-USER-ID") Long userId) {
+        CrewResult result = crewFacade.join(new CrewCriteria.Join(userId, request.code()));
+        return ApiResponse.success(CrewResponse.Join.from(result));
     }
 }

--- a/src/main/java/com/runky/crew/api/CrewController.java
+++ b/src/main/java/com/runky/crew/api/CrewController.java
@@ -7,6 +7,7 @@ import com.runky.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -52,4 +53,12 @@ public class CrewController implements CrewApiSpec {
         return ApiResponse.success(CrewResponse.Detail.from(result));
     }
 
+    @Override
+    @DeleteMapping("/{crewId}/members/me")
+    public ApiResponse<CrewResponse.Leave> leaveCrew(@Valid @RequestBody CrewRequest.Leave request,
+                                                     @PathVariable Long crewId,
+                                                     @RequestHeader("X-USER-ID") Long userId) {
+        CrewResult.Leave result = crewFacade.leaveCrew(new CrewCriteria.Leave(crewId, userId, request.newLeaderId()));
+        return ApiResponse.success(CrewResponse.Leave.from(result));
+    }
 }

--- a/src/main/java/com/runky/crew/api/CrewController.java
+++ b/src/main/java/com/runky/crew/api/CrewController.java
@@ -8,6 +8,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -42,4 +43,13 @@ public class CrewController implements CrewApiSpec {
         List<CrewResult.Card> cards = crewFacade.getCrews(userId);
         return ApiResponse.success(CrewResponse.Cards.from(cards));
     }
+
+    @Override
+    @GetMapping("/{crewId}")
+    public ApiResponse<CrewResponse.Detail> getCrew(@PathVariable Long crewId,
+                                                    @RequestHeader("X-USER-ID") Long userId) {
+        CrewResult.Detail result = crewFacade.getCrew(new CrewCriteria.Detail(crewId, userId));
+        return ApiResponse.success(CrewResponse.Detail.from(result));
+    }
+
 }

--- a/src/main/java/com/runky/crew/api/CrewController.java
+++ b/src/main/java/com/runky/crew/api/CrewController.java
@@ -5,7 +5,9 @@ import com.runky.crew.application.CrewFacade;
 import com.runky.crew.application.CrewResult;
 import com.runky.global.response.ApiResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -32,5 +34,12 @@ public class CrewController implements CrewApiSpec {
                                                    @RequestHeader("X-USER-ID") Long userId) {
         CrewResult result = crewFacade.join(new CrewCriteria.Join(userId, request.code()));
         return ApiResponse.success(CrewResponse.Join.from(result));
+    }
+
+    @Override
+    @GetMapping
+    public ApiResponse<CrewResponse.Cards> getCrews(@RequestHeader("X-USER-ID") Long userId) {
+        List<CrewResult.Card> cards = crewFacade.getCrews(userId);
+        return ApiResponse.success(CrewResponse.Cards.from(cards));
     }
 }

--- a/src/main/java/com/runky/crew/api/CrewRequest.java
+++ b/src/main/java/com/runky/crew/api/CrewRequest.java
@@ -9,6 +9,12 @@ public class CrewRequest {
     ) {
     }
 
+    public record Join(
+            @NotNull(message = "크루 코드는 필수입니다.")
+            String code
+    ) {
+    }
+
     private CrewRequest() {
     }
 }

--- a/src/main/java/com/runky/crew/api/CrewRequest.java
+++ b/src/main/java/com/runky/crew/api/CrewRequest.java
@@ -15,6 +15,11 @@ public class CrewRequest {
     ) {
     }
 
+    public record Leave(
+            Long newLeaderId
+    ) {
+    }
+
     private CrewRequest() {
     }
 }

--- a/src/main/java/com/runky/crew/api/CrewResponse.java
+++ b/src/main/java/com/runky/crew/api/CrewResponse.java
@@ -84,4 +84,21 @@ public class CrewResponse {
 
     private CrewResponse() {
     }
+
+    public record Members(List<Member> members) {
+    }
+
+    public record Member(
+            Long memberId,
+            String nickname,
+            String character
+    ) {
+        public static Member from(CrewResult.CrewMember member) {
+            return new Member(
+                    member.memberId(),
+                    member.nickname(),
+                    member.character()
+            );
+        }
+    }
 }

--- a/src/main/java/com/runky/crew/api/CrewResponse.java
+++ b/src/main/java/com/runky/crew/api/CrewResponse.java
@@ -74,6 +74,14 @@ public class CrewResponse {
         }
     }
 
+    public record Leave(
+            Long crewId
+    ) {
+        public static Leave from(CrewResult.Leave result) {
+            return new Leave(result.crewId());
+        }
+    }
+
     private CrewResponse() {
     }
 }

--- a/src/main/java/com/runky/crew/api/CrewResponse.java
+++ b/src/main/java/com/runky/crew/api/CrewResponse.java
@@ -1,6 +1,7 @@
 package com.runky.crew.api;
 
 import com.runky.crew.application.CrewResult;
+import java.math.BigDecimal;
 import java.util.List;
 
 public class CrewResponse {
@@ -47,6 +48,28 @@ public class CrewResponse {
                     card.memberCount(),
                     card.isLeader(),
                     card.characters()
+            );
+        }
+    }
+
+    public record Detail(
+            Long crewId,
+            String name,
+            String leaderNickname,
+            String notice,
+            Long memberCount,
+            BigDecimal goal,
+            String code
+    ) {
+        public static Detail from(CrewResult.Detail detail) {
+            return new Detail(
+                    detail.crewId(),
+                    detail.name(),
+                    detail.leaderNickname(),
+                    detail.notice(),
+                    detail.memberCount(),
+                    detail.goal(),
+                    detail.code()
             );
         }
     }

--- a/src/main/java/com/runky/crew/api/CrewResponse.java
+++ b/src/main/java/com/runky/crew/api/CrewResponse.java
@@ -13,6 +13,14 @@ public class CrewResponse {
         }
     }
 
+    public record Join(
+            Long crewId
+    ) {
+        public static Join from(CrewResult result) {
+            return new Join(result.id());
+        }
+    }
+
     private CrewResponse() {
     }
 }

--- a/src/main/java/com/runky/crew/api/CrewResponse.java
+++ b/src/main/java/com/runky/crew/api/CrewResponse.java
@@ -1,6 +1,7 @@
 package com.runky.crew.api;
 
 import com.runky.crew.application.CrewResult;
+import java.util.List;
 
 public class CrewResponse {
     public record Create(
@@ -18,6 +19,35 @@ public class CrewResponse {
     ) {
         public static Join from(CrewResult result) {
             return new Join(result.id());
+        }
+    }
+
+    public record Cards(
+            List<Card> crews
+    ) {
+        public static Cards from(List<CrewResult.Card> cards) {
+            List<Card> crewCards = cards.stream()
+                    .map(Card::from)
+                    .toList();
+            return new Cards(crewCards);
+        }
+    }
+
+    public record Card(
+            Long crewId,
+            String name,
+            Long memberCount,
+            boolean isLeader,
+            List<String> characters
+    ) {
+        public static Card from(CrewResult.Card card) {
+            return new Card(
+                    card.crewId(),
+                    card.crewName(),
+                    card.memberCount(),
+                    card.isLeader(),
+                    card.characters()
+            );
         }
     }
 

--- a/src/main/java/com/runky/crew/application/CrewCriteria.java
+++ b/src/main/java/com/runky/crew/application/CrewCriteria.java
@@ -44,6 +44,20 @@ public class CrewCriteria {
         }
     }
 
+    public record Leave(
+            Long crewId,
+            Long userId,
+            Long newLeaderId
+    ) {
+        public CrewCommand.Leave toCommand() {
+            return new CrewCommand.Leave(
+                    crewId,
+                    userId,
+                    newLeaderId
+            );
+        }
+    }
+
     private CrewCriteria() {
     }
 }

--- a/src/main/java/com/runky/crew/application/CrewCriteria.java
+++ b/src/main/java/com/runky/crew/application/CrewCriteria.java
@@ -27,6 +27,11 @@ public class CrewCriteria {
         }
     }
 
+    public record Card(
+            Long userId
+    ) {
+    }
+
     private CrewCriteria() {
     }
 }

--- a/src/main/java/com/runky/crew/application/CrewCriteria.java
+++ b/src/main/java/com/runky/crew/application/CrewCriteria.java
@@ -15,6 +15,18 @@ public class CrewCriteria {
         }
     }
 
+    public record Join(
+            Long userId,
+            String code
+    ) {
+        public CrewCommand.Join toCommand() {
+            return new CrewCommand.Join(
+                    userId,
+                    code
+            );
+        }
+    }
+
     private CrewCriteria() {
     }
 }

--- a/src/main/java/com/runky/crew/application/CrewCriteria.java
+++ b/src/main/java/com/runky/crew/application/CrewCriteria.java
@@ -32,6 +32,18 @@ public class CrewCriteria {
     ) {
     }
 
+    public record Detail(
+            Long crewId,
+            Long userId
+    ) {
+        public CrewCommand.Detail toCrewCommand() {
+            return new CrewCommand.Detail(
+                    crewId,
+                    userId
+            );
+        }
+    }
+
     private CrewCriteria() {
     }
 }

--- a/src/main/java/com/runky/crew/application/CrewCriteria.java
+++ b/src/main/java/com/runky/crew/application/CrewCriteria.java
@@ -58,6 +58,18 @@ public class CrewCriteria {
         }
     }
 
+    public record Members(
+            Long crewId,
+            Long userId
+    ) {
+        public CrewCommand.Members toCommand() {
+            return new CrewCommand.Members(
+                    crewId,
+                    userId
+            );
+        }
+    }
+
     private CrewCriteria() {
     }
 }

--- a/src/main/java/com/runky/crew/application/CrewFacade.java
+++ b/src/main/java/com/runky/crew/application/CrewFacade.java
@@ -1,6 +1,7 @@
 package com.runky.crew.application;
 
 import com.runky.crew.domain.Crew;
+import com.runky.crew.domain.CrewMember;
 import com.runky.crew.domain.CrewService;
 import java.math.BigDecimal;
 import java.util.List;
@@ -37,6 +38,14 @@ public class CrewFacade {
         String leaderNickname = "leader"; // TODO 크루 리더의 닉네임을 가져오는 작업 추가 : UserService
         return new CrewResult.Detail(crew.getId(), crew.getName(), leaderNickname, crew.getNotice(),
                 crew.getActiveMemberCount(), goal, crew.getCode().value());
+    }
+
+    public List<CrewResult.CrewMember> getCrewMembers(CrewCriteria.Members criteria) {
+        List<CrewMember> members = crewService.getCrewMembers(criteria.toCommand());
+        // TODO 크루원 캐릭터 이미지 + 닉네임 불러오는 작업 추가
+        return members.stream()
+                .map(member -> new CrewResult.CrewMember(member.getId(), "nickname", "runky/1.png"))
+                .toList();
     }
 
     public CrewResult.Leave leaveCrew(CrewCriteria.Leave criteria) {

--- a/src/main/java/com/runky/crew/application/CrewFacade.java
+++ b/src/main/java/com/runky/crew/application/CrewFacade.java
@@ -1,8 +1,8 @@
 package com.runky.crew.application;
 
 import com.runky.crew.domain.Crew;
-import com.runky.crew.domain.CrewMember;
 import com.runky.crew.domain.CrewService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -19,5 +19,14 @@ public class CrewFacade {
     public CrewResult join(CrewCriteria.Join criteria) {
         Crew crew = crewService.join(criteria.toCommand());
         return CrewResult.from(crew);
+    }
+
+    public List<CrewResult.Card> getCrews(Long userId) {
+        List<Crew> crews = crewService.getCrewsOfUser(userId);
+        // TODO 크루원 대표 캐릭터 이미지 불러오는 작업 추가
+        return crews.stream()
+                .map(crew -> new CrewResult.Card(crew.getId(), crew.getName(), crew.getActiveMemberCount(),
+                        crew.getLeaderId().equals(userId), List.of("runky/1.pvg", "runky/2.png")))
+                .toList();
     }
 }

--- a/src/main/java/com/runky/crew/application/CrewFacade.java
+++ b/src/main/java/com/runky/crew/application/CrewFacade.java
@@ -38,4 +38,9 @@ public class CrewFacade {
         return new CrewResult.Detail(crew.getId(), crew.getName(), leaderNickname, crew.getNotice(),
                 crew.getActiveMemberCount(), goal, crew.getCode().value());
     }
+
+    public CrewResult.Leave leaveCrew(CrewCriteria.Leave criteria) {
+        Crew crew = crewService.leave(criteria.toCommand());
+        return new CrewResult.Leave(crew.getId(), crew.getName());
+    }
 }

--- a/src/main/java/com/runky/crew/application/CrewFacade.java
+++ b/src/main/java/com/runky/crew/application/CrewFacade.java
@@ -2,6 +2,7 @@ package com.runky.crew.application;
 
 import com.runky.crew.domain.Crew;
 import com.runky.crew.domain.CrewService;
+import java.math.BigDecimal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -28,5 +29,13 @@ public class CrewFacade {
                 .map(crew -> new CrewResult.Card(crew.getId(), crew.getName(), crew.getActiveMemberCount(),
                         crew.getLeaderId().equals(userId), List.of("runky/1.pvg", "runky/2.png")))
                 .toList();
+    }
+
+    public CrewResult.Detail getCrew(CrewCriteria.Detail criteria) {
+        Crew crew = crewService.getCrew(criteria.toCrewCommand());
+        BigDecimal goal = new BigDecimal("10.00"); // TODO 그룹 목표 조합 작업 추가 : GoalService
+        String leaderNickname = "leader"; // TODO 크루 리더의 닉네임을 가져오는 작업 추가 : UserService
+        return new CrewResult.Detail(crew.getId(), crew.getName(), leaderNickname, crew.getNotice(),
+                crew.getActiveMemberCount(), goal, crew.getCode().value());
     }
 }

--- a/src/main/java/com/runky/crew/application/CrewFacade.java
+++ b/src/main/java/com/runky/crew/application/CrewFacade.java
@@ -1,6 +1,7 @@
 package com.runky.crew.application;
 
 import com.runky.crew.domain.Crew;
+import com.runky.crew.domain.CrewMember;
 import com.runky.crew.domain.CrewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,11 @@ public class CrewFacade {
 
     public CrewResult create(CrewCriteria.Create criteria) {
         Crew crew = crewService.create(criteria.toCommand());
+        return CrewResult.from(crew);
+    }
+
+    public CrewResult join(CrewCriteria.Join criteria) {
+        Crew crew = crewService.join(criteria.toCommand());
         return CrewResult.from(crew);
     }
 }

--- a/src/main/java/com/runky/crew/application/CrewResult.java
+++ b/src/main/java/com/runky/crew/application/CrewResult.java
@@ -1,6 +1,7 @@
 package com.runky.crew.application;
 
 import com.runky.crew.domain.Crew;
+import java.util.List;
 
 public record CrewResult(
         Long id,
@@ -19,5 +20,14 @@ public record CrewResult(
                 crew.getNotice(),
                 crew.getActiveMemberCount()
         );
+    }
+
+    public record Card(
+            Long crewId,
+            String crewName,
+            Long memberCount,
+            boolean isLeader,
+            List<String> characters
+    ) {
     }
 }

--- a/src/main/java/com/runky/crew/application/CrewResult.java
+++ b/src/main/java/com/runky/crew/application/CrewResult.java
@@ -17,7 +17,7 @@ public record CrewResult(
                 crew.getCode().value(),
                 crew.getLeaderId(),
                 crew.getNotice(),
-                crew.getMemberCount()
+                crew.getActiveMemberCount()
         );
     }
 }

--- a/src/main/java/com/runky/crew/application/CrewResult.java
+++ b/src/main/java/com/runky/crew/application/CrewResult.java
@@ -42,4 +42,10 @@ public record CrewResult(
             String code
     ) {
     }
+
+    public record Leave(
+            Long crewId,
+            String name
+    ) {
+    }
 }

--- a/src/main/java/com/runky/crew/application/CrewResult.java
+++ b/src/main/java/com/runky/crew/application/CrewResult.java
@@ -43,6 +43,13 @@ public record CrewResult(
     ) {
     }
 
+    public record CrewMember(
+            Long memberId,
+            String nickname,
+            String character
+    ) {
+    }
+
     public record Leave(
             Long crewId,
             String name

--- a/src/main/java/com/runky/crew/application/CrewResult.java
+++ b/src/main/java/com/runky/crew/application/CrewResult.java
@@ -1,6 +1,7 @@
 package com.runky.crew.application;
 
 import com.runky.crew.domain.Crew;
+import java.math.BigDecimal;
 import java.util.List;
 
 public record CrewResult(
@@ -28,6 +29,17 @@ public record CrewResult(
             Long memberCount,
             boolean isLeader,
             List<String> characters
+    ) {
+    }
+
+    public record Detail(
+            Long crewId,
+            String name,
+            String leaderNickname,
+            String notice,
+            Long memberCount,
+            BigDecimal goal,
+            String code
     ) {
     }
 }

--- a/src/main/java/com/runky/crew/domain/Crew.java
+++ b/src/main/java/com/runky/crew/domain/Crew.java
@@ -112,9 +112,26 @@ public class Crew extends BaseTimeEntity {
         incrementActiveMemberCount();
     }
 
+    public void delegateLeader(Long newLeaderId) {
+        if (newLeaderId == null) {
+            throw new GlobalException(CrewErrorCode.HAVE_TO_DELEGATE_LEADER);
+
+        }
+        CrewMember leader = getLeader();
+        leader.demote();
+
+        CrewMember member = getMember(newLeaderId);
+        member.promote();
+        this.leaderId = newLeaderId;
+    }
+
     public boolean hasHistory(Long memberId) {
         return this.members.stream()
                 .anyMatch(member -> member.getMemberId().equals(memberId));
+    }
+
+    public boolean doesNotContainMember(Long memberId) {
+        return !containsMember(memberId);
     }
 
     public boolean containsMember(Long memberId) {

--- a/src/main/java/com/runky/crew/domain/Crew.java
+++ b/src/main/java/com/runky/crew/domain/Crew.java
@@ -85,22 +85,14 @@ public class Crew extends BaseTimeEntity {
     }
 
     public CrewMember banMember(Long memberId) {
-        CrewMember crewMember = this.members.stream()
-                .filter(member -> member.getMemberId().equals(memberId))
-                .findFirst()
-                .orElseThrow(() -> new GlobalException(GlobalErrorCode.NOT_FOUND));
-
+        CrewMember crewMember = getMember(memberId);
         crewMember.ban();
         decrementActiveMemberCount();
         return crewMember;
     }
 
     public CrewMember leaveMember(Long memberId) {
-        CrewMember crewMember = this.members.stream()
-                .filter(member -> member.getMemberId().equals(memberId))
-                .findFirst()
-                .orElseThrow(() -> new GlobalException(GlobalErrorCode.NOT_FOUND));
-
+        CrewMember crewMember = getMember(memberId);
         crewMember.leave();
         decrementActiveMemberCount();
         return crewMember;
@@ -147,6 +139,12 @@ public class Crew extends BaseTimeEntity {
     }
 
     public void decrementActiveMemberCount() {
+        if (this.activeMemberCount == 1) {
+            throw new GlobalException(CrewErrorCode.LAST_CREW_MEMBER);
+        }
+        if (this.activeMemberCount <= 0) {
+            throw new GlobalException(GlobalErrorCode.VALID_EXCEPTION);
+        }
         this.activeMemberCount--;
     }
 
@@ -168,7 +166,7 @@ public class Crew extends BaseTimeEntity {
         return this.members.stream()
                 .filter(member -> member.getMemberId().equals(memberId) && member.isInCrew())
                 .findFirst()
-                .orElseThrow(() -> new GlobalException(GlobalErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
     }
 
     public List<CrewMember> getActiveMembers() {

--- a/src/main/java/com/runky/crew/domain/Crew.java
+++ b/src/main/java/com/runky/crew/domain/Crew.java
@@ -170,4 +170,10 @@ public class Crew extends BaseTimeEntity {
                 .findFirst()
                 .orElseThrow(() -> new GlobalException(GlobalErrorCode.NOT_FOUND));
     }
+
+    public List<CrewMember> getActiveMembers() {
+        return this.members.stream()
+                .filter(CrewMember::isInCrew)
+                .toList();
+    }
 }

--- a/src/main/java/com/runky/crew/domain/Crew.java
+++ b/src/main/java/com/runky/crew/domain/Crew.java
@@ -78,9 +78,9 @@ public class Crew extends BaseTimeEntity {
         incrementActiveMemberCount();
     }
 
-    public boolean contains(Long memberId) {
+    public boolean containsMember(Long memberId) {
         return this.members.stream()
-                .anyMatch(member -> member.getMemberId().equals(memberId));
+                .anyMatch(member -> member.getMemberId().equals(memberId) && member.isInCrew());
     }
 
     public void incrementActiveMemberCount() {
@@ -106,7 +106,7 @@ public class Crew extends BaseTimeEntity {
     }
 
     public CrewMember joinMember(Long memberId) {
-        if (this.members.stream().anyMatch(member -> member.getMemberId().equals(memberId))) {
+        if (containsMember(memberId)) {
             throw new GlobalException(CrewErrorCode.ALREADY_IN_CREW);
         }
         CrewMember crewMember = CrewMember.memberOf(memberId, this);

--- a/src/main/java/com/runky/crew/domain/Crew.java
+++ b/src/main/java/com/runky/crew/domain/Crew.java
@@ -74,7 +74,7 @@ public class Crew extends BaseTimeEntity {
 
     public CrewMember joinMember(Long memberId) {
         if (hasHistory(memberId)) {
-            CrewMember member = getMember(memberId);
+            CrewMember member = getMemberHistory(memberId);
             member.rejoin();
             incrementActiveMemberCount();
             return member;
@@ -140,9 +140,16 @@ public class Crew extends BaseTimeEntity {
                 .orElseThrow(() -> new GlobalException(GlobalErrorCode.NOT_FOUND));
     }
 
-    public CrewMember getMember(Long memberId) {
+    public CrewMember getMemberHistory(Long memberId) {
         return this.members.stream()
                 .filter(member -> member.getMemberId().equals(memberId))
+                .findFirst()
+                .orElseThrow(() -> new GlobalException(GlobalErrorCode.NOT_FOUND));
+    }
+
+    public CrewMember getMember(Long memberId) {
+        return this.members.stream()
+                .filter(member -> member.getMemberId().equals(memberId) && member.isInCrew())
                 .findFirst()
                 .orElseThrow(() -> new GlobalException(GlobalErrorCode.NOT_FOUND));
     }

--- a/src/main/java/com/runky/crew/domain/CrewCommand.java
+++ b/src/main/java/com/runky/crew/domain/CrewCommand.java
@@ -13,6 +13,12 @@ public class CrewCommand {
     ) {
     }
 
+    public record Detail(
+            Long crewId,
+            Long userId
+    ) {
+    }
+
     private CrewCommand() {
     }
 }

--- a/src/main/java/com/runky/crew/domain/CrewCommand.java
+++ b/src/main/java/com/runky/crew/domain/CrewCommand.java
@@ -7,6 +7,12 @@ public class CrewCommand {
     ) {
     }
 
+    public record Join(
+            Long userId,
+            String code
+    ) {
+    }
+
     private CrewCommand() {
     }
 }

--- a/src/main/java/com/runky/crew/domain/CrewCommand.java
+++ b/src/main/java/com/runky/crew/domain/CrewCommand.java
@@ -26,6 +26,12 @@ public class CrewCommand {
     ) {
     }
 
+    public record Members(
+            Long crewId,
+            Long userId
+    ) {
+    }
+
     private CrewCommand() {
     }
 }

--- a/src/main/java/com/runky/crew/domain/CrewCommand.java
+++ b/src/main/java/com/runky/crew/domain/CrewCommand.java
@@ -19,6 +19,13 @@ public class CrewCommand {
     ) {
     }
 
+    public record Leave(
+            Long crewId,
+            Long userId,
+            Long newLeaderId
+    ) {
+    }
+
     private CrewCommand() {
     }
 }

--- a/src/main/java/com/runky/crew/domain/CrewConstants.java
+++ b/src/main/java/com/runky/crew/domain/CrewConstants.java
@@ -1,7 +1,8 @@
 package com.runky.crew.domain;
 
 public enum CrewConstants {
-    CAPACITY(6),
+    CREW_CAPACITY(6),
+    MAX_CREW_COUNT(5),
     CODE_LENGTH(6),
     MAX_CREW_NAME_LENGTH(15),
     MAX_CREW_NOTICE_LENGTH(20);

--- a/src/main/java/com/runky/crew/domain/CrewMember.java
+++ b/src/main/java/com/runky/crew/domain/CrewMember.java
@@ -75,6 +75,20 @@ public class CrewMember extends BaseTimeEntity {
         this.role = Role.LEFT;
     }
 
+    public void demote() {
+        if (!isLeader()) {
+            throw new GlobalException(CrewErrorCode.NOT_CREW_LEADER);
+        }
+        this.role = Role.MEMBER;
+    }
+
+    public void promote() {
+        if (this.role != Role.MEMBER) {
+            throw new GlobalException(CrewErrorCode.NOT_CREW_MEMBER);
+        }
+        this.role = Role.LEADER;
+    }
+
     public boolean isLeader() {
         return this.role == Role.LEADER;
     }

--- a/src/main/java/com/runky/crew/domain/CrewMember.java
+++ b/src/main/java/com/runky/crew/domain/CrewMember.java
@@ -72,6 +72,12 @@ public class CrewMember extends BaseTimeEntity {
     }
 
     public void leave() {
+        if (this.role == Role.LEADER) {
+            throw new GlobalException(CrewErrorCode.HAVE_TO_DELEGATE_LEADER);
+        }
+        if (this.role == Role.BANNED || this.role == Role.LEFT) {
+            throw new GlobalException(CrewErrorCode.NOT_CREW_MEMBER);
+        }
         this.role = Role.LEFT;
     }
 

--- a/src/main/java/com/runky/crew/domain/CrewMember.java
+++ b/src/main/java/com/runky/crew/domain/CrewMember.java
@@ -1,6 +1,8 @@
 package com.runky.crew.domain;
 
+import com.runky.crew.error.CrewErrorCode;
 import com.runky.global.entity.BaseTimeEntity;
+import com.runky.global.error.GlobalException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -47,16 +49,48 @@ public class CrewMember extends BaseTimeEntity {
         return new CrewMember(crew.getLeaderId(), crew, Role.LEADER);
     }
 
+    public static CrewMember memberOf(Long memberId, Crew crew) {
+        return new CrewMember(memberId, crew, Role.MEMBER);
+    }
+
     public void join(Crew crew) {
         this.crew = crew;
+    }
+
+    public void rejoin() {
+        if (isBanned()) {
+            throw new GlobalException(CrewErrorCode.BANNED_MEMBER);
+        }
+        if (isInCrew()) {
+            throw new GlobalException(CrewErrorCode.ALREADY_IN_CREW);
+        }
+        this.role = Role.MEMBER;
+    }
+
+    public void ban() {
+        this.role = Role.BANNED;
+    }
+
+    public void leave() {
+        this.role = Role.LEFT;
     }
 
     public boolean isLeader() {
         return this.role == Role.LEADER;
     }
 
+    public boolean isBanned() {
+        return this.role == Role.BANNED;
+    }
+
+    public boolean isInCrew() {
+        return this.role == Role.LEADER || this.role == Role.MEMBER;
+    }
+
     public enum Role {
         LEADER,
-        MEMBER
+        MEMBER,
+        LEFT,
+        BANNED
     }
 }

--- a/src/main/java/com/runky/crew/domain/CrewMemberCount.java
+++ b/src/main/java/com/runky/crew/domain/CrewMemberCount.java
@@ -42,7 +42,7 @@ public class CrewMemberCount {
     }
 
     public boolean isOver() {
-        return crewCount >= CrewConstants.CAPACITY.value();
+        return crewCount >= CrewConstants.MAX_CREW_COUNT.value();
     }
 
     public void increment() {

--- a/src/main/java/com/runky/crew/domain/CrewMemberCount.java
+++ b/src/main/java/com/runky/crew/domain/CrewMemberCount.java
@@ -51,4 +51,11 @@ public class CrewMemberCount {
         }
         crewCount++;
     }
+
+    public void decrement() {
+        if (crewCount <= 0) {
+            throw new GlobalException(CrewErrorCode.NOT_IN_CREW);
+        }
+        crewCount--;
+    }
 }

--- a/src/main/java/com/runky/crew/domain/CrewRepository.java
+++ b/src/main/java/com/runky/crew/domain/CrewRepository.java
@@ -5,15 +5,17 @@ import java.util.Optional;
 
 public interface CrewRepository {
 
-    Crew save(Crew crew);
-
     Optional<Crew> findById(Long crewId);
+
+    Optional<Crew> findCrewByCode(Code code);
 
     Optional<CrewMember> findByCrewAndMember(Long crewId, Long memberId);
 
     List<CrewMember> findCrewMemberOfUser(Long memberId);
 
-    CrewMemberCount save(CrewMemberCount crewMemberCount);
-
     Optional<CrewMemberCount> findCountByMemberId(Long memberId);
+
+    Crew save(Crew crew);
+
+    CrewMemberCount save(CrewMemberCount crewMemberCount);
 }

--- a/src/main/java/com/runky/crew/domain/CrewRepository.java
+++ b/src/main/java/com/runky/crew/domain/CrewRepository.java
@@ -9,6 +9,8 @@ public interface CrewRepository {
 
     Optional<Crew> findCrewByCode(Code code);
 
+    List<Crew> findCrewsByMemberId(Long memberId);
+
     Optional<CrewMember> findByCrewAndMember(Long crewId, Long memberId);
 
     List<CrewMember> findCrewMemberOfUser(Long memberId);

--- a/src/main/java/com/runky/crew/domain/CrewService.java
+++ b/src/main/java/com/runky/crew/domain/CrewService.java
@@ -3,6 +3,7 @@ package com.runky.crew.domain;
 import com.runky.crew.error.CrewErrorCode;
 import com.runky.global.error.GlobalErrorCode;
 import com.runky.global.error.GlobalException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,5 +38,10 @@ public class CrewService {
         crewMemberCount.increment();
 
         return crew;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Crew> getCrewsOfUser(Long userId) {
+        return crewRepository.findCrewsByMemberId(userId);
     }
 }

--- a/src/main/java/com/runky/crew/domain/CrewService.java
+++ b/src/main/java/com/runky/crew/domain/CrewService.java
@@ -29,7 +29,7 @@ public class CrewService {
         Crew crew = crewRepository.findCrewByCode(new Code(command.code()))
                 .orElseThrow(() -> new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
 
-        CrewMember crewmember = crew.joinMember(command.userId());
+        crew.joinMember(command.userId());
 
         CrewMemberCount crewMemberCount = crewRepository.findCountByMemberId(command.userId())
                 .orElseThrow(() -> new GlobalException(GlobalErrorCode.NOT_FOUND));

--- a/src/main/java/com/runky/crew/domain/CrewService.java
+++ b/src/main/java/com/runky/crew/domain/CrewService.java
@@ -29,7 +29,7 @@ public class CrewService {
         Crew crew = crewRepository.findCrewByCode(new Code(command.code()))
                 .orElseThrow(() -> new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
 
-        CrewMember crewMember = (crew.contains(command.userId())) ?
+        CrewMember crewMember = (crew.containsMember(command.userId())) ?
                 crew.rejoinMember(command.userId()) :
                 crew.joinMember(command.userId());
 
@@ -43,5 +43,15 @@ public class CrewService {
     @Transactional(readOnly = true)
     public List<Crew> getCrewsOfUser(Long userId) {
         return crewRepository.findCrewsByMemberId(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public Crew getCrew(CrewCommand.Detail command) {
+        Crew crew = crewRepository.findById(command.crewId())
+                .orElseThrow(() -> new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
+        if (!crew.containsMember(command.userId())) {
+            throw new GlobalException(CrewErrorCode.NOT_CREW_MEMBER);
+        }
+        return crew;
     }
 }

--- a/src/main/java/com/runky/crew/domain/CrewService.java
+++ b/src/main/java/com/runky/crew/domain/CrewService.java
@@ -53,6 +53,16 @@ public class CrewService {
         return crew;
     }
 
+    @Transactional(readOnly = true)
+    public List<CrewMember> getCrewMembers(CrewCommand.Members command) {
+        Crew crew = crewRepository.findById(command.crewId())
+                .orElseThrow(() -> new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
+        if (crew.doesNotContainMember(command.userId())) {
+            throw new GlobalException(CrewErrorCode.NOT_CREW_MEMBER);
+        }
+        return crew.getActiveMembers();
+    }
+
     @Transactional
     public Crew leave(CrewCommand.Leave command) {
         Crew crew = crewRepository.findById(command.crewId())

--- a/src/main/java/com/runky/crew/domain/CrewService.java
+++ b/src/main/java/com/runky/crew/domain/CrewService.java
@@ -75,6 +75,9 @@ public class CrewService {
             crew.delegateLeader(command.newLeaderId());
         }
         crew.leaveMember(command.userId());
+        CrewMemberCount crewMemberCount = crewRepository.findCountByMemberId(command.userId())
+                .orElseThrow(() -> new GlobalException(GlobalErrorCode.NOT_FOUND));
+        crewMemberCount.decrement();
         return crew;
     }
 }

--- a/src/main/java/com/runky/crew/domain/CrewService.java
+++ b/src/main/java/com/runky/crew/domain/CrewService.java
@@ -47,9 +47,24 @@ public class CrewService {
     public Crew getCrew(CrewCommand.Detail command) {
         Crew crew = crewRepository.findById(command.crewId())
                 .orElseThrow(() -> new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
-        if (!crew.containsMember(command.userId())) {
+        if (crew.doesNotContainMember(command.userId())) {
             throw new GlobalException(CrewErrorCode.NOT_CREW_MEMBER);
         }
+        return crew;
+    }
+
+    @Transactional
+    public Crew leave(CrewCommand.Leave command) {
+        Crew crew = crewRepository.findById(command.crewId())
+                .orElseThrow(() -> new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
+        if (crew.doesNotContainMember(command.userId())) {
+            throw new GlobalException(CrewErrorCode.NOT_CREW_MEMBER);
+        }
+        CrewMember member = crew.getMember(command.userId());
+        if (member.isLeader()) {
+            crew.delegateLeader(command.newLeaderId());
+        }
+        crew.leaveMember(command.userId());
         return crew;
     }
 }

--- a/src/main/java/com/runky/crew/domain/CrewService.java
+++ b/src/main/java/com/runky/crew/domain/CrewService.java
@@ -29,9 +29,7 @@ public class CrewService {
         Crew crew = crewRepository.findCrewByCode(new Code(command.code()))
                 .orElseThrow(() -> new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
 
-        CrewMember crewMember = (crew.containsMember(command.userId())) ?
-                crew.rejoinMember(command.userId()) :
-                crew.joinMember(command.userId());
+        CrewMember crewmember = crew.joinMember(command.userId());
 
         CrewMemberCount crewMemberCount = crewRepository.findCountByMemberId(command.userId())
                 .orElseThrow(() -> new GlobalException(GlobalErrorCode.NOT_FOUND));

--- a/src/main/java/com/runky/crew/error/CrewErrorCode.java
+++ b/src/main/java/com/runky/crew/error/CrewErrorCode.java
@@ -21,6 +21,7 @@ public enum CrewErrorCode implements ErrorCode {
     NOT_CREW_LEADER(HttpStatus.FORBIDDEN, "C110", "크루 리더가 아닙니다."),
     HAVE_TO_DELEGATE_LEADER(HttpStatus.BAD_REQUEST, "C111", "리더는 탈퇴 전 다른 멤버에게 리더를 위임해야 합니다."),
     NOT_IN_CREW(HttpStatus.BAD_REQUEST, "C112", "현재 참여중인 크루가 없습니다."),
+    LAST_CREW_MEMBER(HttpStatus.BAD_REQUEST, "C113", "크루에 마지막으로 남은 사용자는 탈퇴 대신 해체해야 합니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/runky/crew/error/CrewErrorCode.java
+++ b/src/main/java/com/runky/crew/error/CrewErrorCode.java
@@ -17,6 +17,7 @@ public enum CrewErrorCode implements ErrorCode {
     NOT_FOUND_CREW(HttpStatus.NOT_FOUND, "C106", "크루를 찾을 수 없습니다."),
     BANNED_MEMBER(HttpStatus.FORBIDDEN, "C107", "추방된 멤버입니다."),
     ALREADY_IN_CREW(HttpStatus.CONFLICT, "C108", "이미 크루에 참여한 상태입니다."),
+    NOT_CREW_MEMBER(HttpStatus.FORBIDDEN, "C109", "크루 멤버가 아닙니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/runky/crew/error/CrewErrorCode.java
+++ b/src/main/java/com/runky/crew/error/CrewErrorCode.java
@@ -18,6 +18,9 @@ public enum CrewErrorCode implements ErrorCode {
     BANNED_MEMBER(HttpStatus.FORBIDDEN, "C107", "추방된 멤버입니다."),
     ALREADY_IN_CREW(HttpStatus.CONFLICT, "C108", "이미 크루에 참여한 상태입니다."),
     NOT_CREW_MEMBER(HttpStatus.FORBIDDEN, "C109", "크루 멤버가 아닙니다."),
+    NOT_CREW_LEADER(HttpStatus.FORBIDDEN, "C110", "크루 리더가 아닙니다."),
+    HAVE_TO_DELEGATE_LEADER(HttpStatus.BAD_REQUEST, "C111", "리더는 탈퇴 전 다른 멤버에게 리더를 위임해야 합니다."),
+
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/runky/crew/error/CrewErrorCode.java
+++ b/src/main/java/com/runky/crew/error/CrewErrorCode.java
@@ -20,7 +20,7 @@ public enum CrewErrorCode implements ErrorCode {
     NOT_CREW_MEMBER(HttpStatus.FORBIDDEN, "C109", "크루 멤버가 아닙니다."),
     NOT_CREW_LEADER(HttpStatus.FORBIDDEN, "C110", "크루 리더가 아닙니다."),
     HAVE_TO_DELEGATE_LEADER(HttpStatus.BAD_REQUEST, "C111", "리더는 탈퇴 전 다른 멤버에게 리더를 위임해야 합니다."),
-
+    NOT_IN_CREW(HttpStatus.BAD_REQUEST, "C112", "현재 참여중인 크루가 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/runky/crew/error/CrewErrorCode.java
+++ b/src/main/java/com/runky/crew/error/CrewErrorCode.java
@@ -13,6 +13,10 @@ public enum CrewErrorCode implements ErrorCode {
     BLANK_CREW_NAME(HttpStatus.BAD_REQUEST, "C102", "크루 이름은 공백일 수 없습니다."),
     OVER_CODE_LENGTH(HttpStatus.BAD_REQUEST, "C103", "코드의 길이는 6자여야 합니다."),
     INVALID_CODE_PATTERN(HttpStatus.BAD_REQUEST, "C104", "코드는 영문 대소문자와 숫자만 포함할 수 있습니다."),
+    OVER_CREW_MEMBER_COUNT(HttpStatus.CONFLICT, "C105", "크루는 최대 6명까지 참여할 수 있습니다."),
+    NOT_FOUND_CREW(HttpStatus.NOT_FOUND, "C106", "크루를 찾을 수 없습니다."),
+    BANNED_MEMBER(HttpStatus.FORBIDDEN, "C107", "추방된 멤버입니다."),
+    ALREADY_IN_CREW(HttpStatus.CONFLICT, "C108", "이미 크루에 참여한 상태입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/runky/crew/infrastructure/CrewJpaRepository.java
+++ b/src/main/java/com/runky/crew/infrastructure/CrewJpaRepository.java
@@ -2,10 +2,15 @@ package com.runky.crew.infrastructure;
 
 import com.runky.crew.domain.Code;
 import com.runky.crew.domain.Crew;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CrewJpaRepository extends JpaRepository<Crew, Long> {
 
     Optional<Crew> findByCode(Code code);
+
+    @Query("SELECT c FROM Crew c JOIN c.members m WHERE m.memberId = :memberId AND (m.role = 'LEADER' OR m.role = 'MEMBER')")
+    List<Crew> findCrewsByMemberId(Long memberId);
 }

--- a/src/main/java/com/runky/crew/infrastructure/CrewJpaRepository.java
+++ b/src/main/java/com/runky/crew/infrastructure/CrewJpaRepository.java
@@ -1,7 +1,11 @@
 package com.runky.crew.infrastructure;
 
+import com.runky.crew.domain.Code;
 import com.runky.crew.domain.Crew;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CrewJpaRepository extends JpaRepository<Crew, Long> {
+
+    Optional<Crew> findByCode(Code code);
 }

--- a/src/main/java/com/runky/crew/infrastructure/CrewRepositoryImpl.java
+++ b/src/main/java/com/runky/crew/infrastructure/CrewRepositoryImpl.java
@@ -34,6 +34,11 @@ public class CrewRepositoryImpl implements CrewRepository {
     }
 
     @Override
+    public List<Crew> findCrewsByMemberId(Long memberId) {
+        return crewJpaRepository.findCrewsByMemberId(memberId);
+    }
+
+    @Override
     public Optional<CrewMember> findByCrewAndMember(Long crewId, Long memberId) {
         return crewMemberJpaRepository.findByCrewIdAndMemberId(crewId, memberId);
     }

--- a/src/main/java/com/runky/crew/infrastructure/CrewRepositoryImpl.java
+++ b/src/main/java/com/runky/crew/infrastructure/CrewRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.runky.crew.infrastructure;
 
+import com.runky.crew.domain.Code;
 import com.runky.crew.domain.Crew;
 import com.runky.crew.domain.CrewMember;
 import com.runky.crew.domain.CrewRepository;
@@ -25,6 +26,11 @@ public class CrewRepositoryImpl implements CrewRepository {
     @Override
     public Optional<Crew> findById(Long crewId) {
         return crewJpaRepository.findById(crewId);
+    }
+
+    @Override
+    public Optional<Crew> findCrewByCode(Code code) {
+        return crewJpaRepository.findByCode(code);
     }
 
     @Override

--- a/src/test/java/com/runky/crew/api/CrewApiE2ETest.java
+++ b/src/test/java/com/runky/crew/api/CrewApiE2ETest.java
@@ -169,6 +169,9 @@ class CrewApiE2ETest {
             Crew crew = Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123"));
             crew.joinMember(2L);
             Crew savedCrew = crewRepository.save(crew);
+            CrewMemberCount crewMemberCount = CrewMemberCount.of(2L);
+            crewMemberCount.increment();
+            crewRepository.save(crewMemberCount);
 
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.add("X-USER-ID", String.valueOf(2L));

--- a/src/test/java/com/runky/crew/domain/CrewMemberCountTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewMemberCountTest.java
@@ -36,4 +36,17 @@ class CrewMemberCountTest {
                 .usingRecursiveComparison()
                 .isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_COUNT));
     }
+
+    @Test
+    @DisplayName("속한 크루 개수가 0개인 경우, decrement 시, NOT_IN_CREW 예외가 발생한다.")
+    void throwNotInCrewException_whenDecrementFromZero() {
+        Long userId = 1L;
+        CrewMemberCount crewMemberCount = CrewMemberCount.of(userId);
+
+        GlobalException thrown = assertThrows(GlobalException.class, crewMemberCount::decrement);
+
+        assertThat(thrown)
+                .usingRecursiveComparison()
+                .isEqualTo(new GlobalException(CrewErrorCode.NOT_IN_CREW));
+    }
 }

--- a/src/test/java/com/runky/crew/domain/CrewMemberTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewMemberTest.java
@@ -45,9 +45,9 @@ class CrewMemberTest {
         void throwBannedMemberException_whenBanned() {
             Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("ABC123"));
             crew.joinMember(2L);
-            crew.banMember(2L);
+            CrewMember crewMember = crew.banMember(2L);
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.rejoinMember(2L));
+            GlobalException thrown = assertThrows(GlobalException.class, crewMember::rejoin);
 
             assertThat(thrown)
                     .usingRecursiveComparison()
@@ -58,9 +58,9 @@ class CrewMemberTest {
         @DisplayName("이미 가입된 크루라면, ALREADY_IN_CREW 예외가 발생한다.")
         void throwAlreadyInCrewException_whenAlreadyJoined() {
             Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("ABC123"));
-            crew.joinMember(2L);
+            CrewMember crewMember = crew.joinMember(2L);
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.rejoinMember(2L));
+            GlobalException thrown = assertThrows(GlobalException.class, crewMember::rejoin);
 
             assertThat(thrown)
                     .usingRecursiveComparison()

--- a/src/test/java/com/runky/crew/domain/CrewMemberTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewMemberTest.java
@@ -1,7 +1,11 @@
 package com.runky.crew.domain;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
+import com.runky.crew.error.CrewErrorCode;
+import com.runky.global.error.GlobalException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,5 +25,72 @@ class CrewMemberTest {
 
             assertThat(leader.getRole()).isEqualTo(CrewMember.Role.LEADER);
         }
+
+        @Test
+        @DisplayName("일반 크루원을 생성할 수 있다.")
+        void createMember() {
+            Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("ABC123"));
+
+            CrewMember member = CrewMember.memberOf(2L, crew);
+
+            assertThat(member.getRole()).isEqualTo(CrewMember.Role.MEMBER);
+        }
+    }
+
+    @Nested
+    @DisplayName("크루 재가입 할 시,")
+    class Rejoin {
+        @Test
+        @DisplayName("추방된 크루라면, BANNED_MEMBER 예외가 발생한다.")
+        void throwBannedMemberException_whenBanned() {
+            Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("ABC123"));
+            crew.joinMember(2L);
+            crew.banMember(2L);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.rejoinMember(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(CrewErrorCode.BANNED_MEMBER));
+        }
+
+        @Test
+        @DisplayName("이미 가입된 크루라면, ALREADY_IN_CREW 예외가 발생한다.")
+        void throwAlreadyInCrewException_whenAlreadyJoined() {
+            Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("ABC123"));
+            crew.joinMember(2L);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.rejoinMember(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(CrewErrorCode.ALREADY_IN_CREW));
+        }
+    }
+
+    @Test
+    @DisplayName("크루원이 추방될 경우, 상태는 BANNED로 변경된다.")
+    void banMember() {
+        Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("ABC123"));
+        CrewMember crewMember = CrewMember.memberOf(1L, crew);
+
+        crewMember.ban();
+
+        assertThat(crewMember.getRole()).isEqualTo(CrewMember.Role.BANNED);
+    }
+
+    @Test
+    @DisplayName("크루의 리더와 멤버는 크루에 속해있다고 판단한다.")
+    void isInCrew() {
+        Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("ABC123"));
+
+        CrewMember leader = crew.getLeader();
+        CrewMember member = CrewMember.memberOf(1L, crew);
+
+        boolean isLeaderInCrew = leader.isInCrew();
+        boolean isMemberInCrew = member.isInCrew();
+
+        assertThat(isLeaderInCrew).isTrue();
+        assertThat(isMemberInCrew).isTrue();
     }
 }

--- a/src/test/java/com/runky/crew/domain/CrewServiceIntegrationTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewServiceIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.runky.crew.domain;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.runky.utils.DatabaseCleanUp;
@@ -80,6 +79,18 @@ class CrewServiceIntegrationTest {
         }
     }
 
+    @Test
+    @DisplayName("사용자가 속한 크루를 조회한다.")
+    void getCrewsOfUser() {
+        crewRepository.save(Crew.of(new CrewCommand.Create(1L, "Crew 1"), new Code("abc123")));
+        crewRepository.save(Crew.of(new CrewCommand.Create(1L, "Crew 2"), new Code("abc123")));
+        crewRepository.save(Crew.of(new CrewCommand.Create(1L, "Crew 3"), new Code("abc123")));
+
+        List<Crew> crews = crewService.getCrewsOfUser(1L);
+
+        assertThat(crews).hasSize(3);
+    }
+
     @Nested
     @DisplayName("동시성 테스트")
     class Concurrency {
@@ -107,7 +118,6 @@ class CrewServiceIntegrationTest {
             }
             start.countDown();
             latch.await();
-
 
             CrewMemberCount crewMemberCount = crewRepository.findCountByMemberId(1L).orElseThrow();
             List<CrewMember> crewMembers = crewRepository.findCrewMemberOfUser(1L);

--- a/src/test/java/com/runky/crew/domain/CrewServiceIntegrationTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewServiceIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.runky.crew.domain;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.runky.utils.DatabaseCleanUp;
@@ -55,6 +56,27 @@ class CrewServiceIntegrationTest {
             CrewMember crewMember = crewRepository.findByCrewAndMember(crew.getId(), 1L).orElseThrow();
             assertThat(crew.getLeaderId()).isEqualTo(crewMember.getMemberId());
             assertThat(crewMember.isLeader()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("크루 가입 시,")
+    class Join {
+
+        @Test
+        @DisplayName("재가입하는 경우, 기존 CrewMember의 상태가 MEMBER로 변경된다.")
+        void rejoinCrewMember() {
+            Crew crew = Crew.of(new CrewCommand.Create(1L, "Crew"), new Code("ABC123"));
+            crew.joinMember(2L);
+            crew.joinMember(3L);
+            CrewMember before = crew.leaveMember(3L);
+            crewRepository.save(CrewMemberCount.of(3L));
+            Crew saveCrew = crewRepository.save(crew);
+
+            Crew joinedCrew = crewService.join(new CrewCommand.Join(3L, saveCrew.getCode().value()));
+
+            assertThat(before.getRole()).isEqualTo(CrewMember.Role.LEFT);
+            assertThat(joinedCrew.getMember(3L).getRole()).isEqualTo(CrewMember.Role.MEMBER);
         }
     }
 

--- a/src/test/java/com/runky/crew/domain/CrewTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewTest.java
@@ -95,62 +95,39 @@ class CrewTest {
     }
 
     @Nested
-    @DisplayName("크루원 재가입 시,")
-    class Rejoin {
+    @DisplayName("크루 가입 시,")
+    class Join {
 
         @Test
-        @DisplayName("가입하지 않았던 사용자의 재가입 요청일 경우, NOT_FOUND 예외가 발생한다.")
-        void throwNotFoundException_whenRejoiningMemberNotInCrew() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.rejoinMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
-        }
-
-        @Test
-        @DisplayName("사용자가 크루에 재가입 요청할 때, 가입한 적이 없다면, NOT_FOUND 예외가 발생한다.")
-        void throwNotFoundException_whenRejoiningMemberNotFound() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.rejoinMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
-        }
-
-        @Test
-        @DisplayName("크루원이 이미 꽉 차있다면, OVER_CREW_MEMBER_COUNT 예외가 발생한다.")
-        void throwOverCrewMemberCountException_whenRejoiningFullCrew() {
+        @DisplayName("가입한 기록이 있는 경우, 추방된 멤버라면, BANNED_MEMBER 예외가 발생한다.")
+        void throwBannedMemberException_whenJoiningBannedMember() {
             CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
             Code code = new Code("ABC123");
             Crew crew = Crew.of(command, code);
             crew.joinMember(2L);
-            crew.joinMember(3L);
-            crew.joinMember(4L);
-            crew.joinMember(5L);
-            crew.joinMember(6L);
-            crew.leaveMember(6L);
-            crew.joinMember(7L);
+            crew.banMember(2L);
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.rejoinMember(6L));
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(2L));
 
             assertThat(thrown)
                     .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_MEMBER_COUNT));
+                    .isEqualTo(new GlobalException(CrewErrorCode.BANNED_MEMBER));
         }
-    }
 
-    @Nested
-    @DisplayName("크루 가입 시,")
-    class Join {
+        @Test
+        @DisplayName("가입한 기록이 있는 경우, 이미 가입된 멤버라면, ALREADY_IN_CREW 예외가 발생한다.")
+        void throwAlreadyInCrewException_whenJoiningAlreadyJoinedMember() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+            crew.joinMember(2L);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(CrewErrorCode.ALREADY_IN_CREW));
+        }
 
         @Test
         @DisplayName("이미 가입한 크루일 경우, ALREADY_IN_CREW 예외가 발생한다.")

--- a/src/test/java/com/runky/crew/domain/CrewTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.runky.crew.error.CrewErrorCode;
 import com.runky.global.error.GlobalErrorCode;
 import com.runky.global.error.GlobalException;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -377,6 +378,29 @@ class CrewTest {
 
             assertThat(member.getMemberId()).isEqualTo(2L);
             assertThat(member.getRole()).isEqualTo(CrewMember.Role.MEMBER);
+        }
+    }
+
+    @Nested
+    @DisplayName("크루의 활동 멤버 조회 시,")
+    class GetActiveMembers {
+
+        @Test
+        @DisplayName("크루의 활동 멤버를 조회한다.")
+        void getActiveMembers() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+            crew.joinMember(2L);
+            crew.joinMember(3L);
+            crew.joinMember(4L);
+            crew.leaveMember(4L);
+
+            List<CrewMember> activeMembers = crew.getActiveMembers();
+
+            assertThat(activeMembers).hasSize(3);
+            assertThat(activeMembers).extracting("memberId")
+                    .containsExactlyInAnyOrder(1L, 2L, 3L);
         }
     }
 }

--- a/src/test/java/com/runky/crew/domain/CrewTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewTest.java
@@ -245,18 +245,88 @@ class CrewTest {
         assertThat(leader.getMemberId()).isEqualTo(1L);
     }
 
-    @Test
-    @DisplayName("크루의 멤버를 조회한다.")
-    void getMember() {
-        CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-        Code code = new Code("ABC123");
-        Crew crew = Crew.of(command, code);
-        crew.joinMember(2L);
-        crew.joinMember(3L);
+    @Nested
+    @DisplayName("크루 내 가입했던 멤버 조회 시,")
+    class GetHistory {
 
-        CrewMember member = crew.getMember(2L);
+        @Test
+        @DisplayName("가입한 적이 없다면, NOT_FOUND 예외가 발생한다.")
+        void throwNotFoundException_whenGettingNonExistentMemberHistory() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
 
-        assertThat(member.getMemberId()).isEqualTo(2L);
-        assertThat(member.getRole()).isEqualTo(CrewMember.Role.MEMBER);
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMemberHistory(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
+        }
+    }
+
+    @Nested
+    @DisplayName("크루 내 활동중인 멤버 조회 시,")
+    class GetMember {
+
+        @Test
+        @DisplayName("크루 내 활동중인 멤버 조회 시, 멤버가 존재하지 않다면, NOT_FOUND 예외가 발생한다.")
+        void throwNotFoundException_whenGettingNonExistentMember() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMember(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("크루 내 활동중인 멤버 조회 시, 탈퇴한 멤버라면, NOT_FOUND 예외가 발생한다.")
+        void throwNotFoundException_whenGettingLeftMember() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+            crew.joinMember(2L);
+            crew.leaveMember(2L);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMember(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("크루 내 활동중인 멤버 조회 시, 추방 멤버라면, NOT_FOUND 예외가 발생한다.")
+        void throwNotFoundException_whenGettingBannedMember() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+            crew.joinMember(2L);
+            crew.banMember(2L);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMember(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("크루의 멤버를 조회한다.")
+        void getMember() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+            crew.joinMember(2L);
+            crew.joinMember(3L);
+
+            CrewMember member = crew.getMember(2L);
+
+            assertThat(member.getMemberId()).isEqualTo(2L);
+            assertThat(member.getRole()).isEqualTo(CrewMember.Role.MEMBER);
+        }
     }
 }

--- a/src/test/java/com/runky/crew/domain/CrewTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.runky.crew.error.CrewErrorCode;
+import com.runky.global.error.GlobalErrorCode;
 import com.runky.global.error.GlobalException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -58,7 +59,7 @@ class CrewTest {
 
             Crew crew = Crew.of(command, code);
 
-            assertThat(crew.getMemberCount()).isEqualTo(1L);
+            assertThat(crew.getActiveMemberCount()).isEqualTo(1L);
         }
 
         @Test
@@ -72,5 +73,213 @@ class CrewTest {
             assertThat(crew.getMembers()).hasSize(1);
             assertThat(crew.getMembers().get(0).getRole()).isEqualTo(CrewMember.Role.LEADER);
         }
+    }
+
+    @Test
+    @DisplayName("크루원 추가 시, 인원 수가 초과하면, OVER_CREW_MEMBER_COUNT 예외가 발생한다.")
+    void throwOverCrewMemberCountException_whenAddingMemberExceedsCapacity() {
+        CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+        Code code = new Code("ABC123");
+        Crew crew = Crew.of(command, code);
+        crew.joinMember(2L);
+        crew.joinMember(3L);
+        crew.joinMember(4L);
+        crew.joinMember(5L);
+        crew.joinMember(6L);
+
+        GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(7L));
+
+        assertThat(thrown)
+                .usingRecursiveComparison()
+                .isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_MEMBER_COUNT));
+    }
+
+    @Nested
+    @DisplayName("크루원 재가입 시,")
+    class Rejoin {
+
+        @Test
+        @DisplayName("가입하지 않았던 사용자의 재가입 요청일 경우, NOT_FOUND 예외가 발생한다.")
+        void throwNotFoundException_whenRejoiningMemberNotInCrew() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.rejoinMember(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("사용자가 크루에 재가입 요청할 때, 가입한 적이 없다면, NOT_FOUND 예외가 발생한다.")
+        void throwNotFoundException_whenRejoiningMemberNotFound() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.rejoinMember(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("크루원이 이미 꽉 차있다면, OVER_CREW_MEMBER_COUNT 예외가 발생한다.")
+        void throwOverCrewMemberCountException_whenRejoiningFullCrew() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+            crew.joinMember(2L);
+            crew.joinMember(3L);
+            crew.joinMember(4L);
+            crew.joinMember(5L);
+            crew.joinMember(6L);
+            crew.leaveMember(6L);
+            crew.joinMember(7L);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.rejoinMember(6L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_MEMBER_COUNT));
+        }
+    }
+
+    @Nested
+    @DisplayName("크루 가입 시,")
+    class Join {
+
+        @Test
+        @DisplayName("이미 가입한 크루일 경우, ALREADY_IN_CREW 예외가 발생한다.")
+        void throwAlreadyInCrewException_whenJoiningAlreadyJoinedCrew() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+            crew.joinMember(2L);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(CrewErrorCode.ALREADY_IN_CREW));
+        }
+
+        @Test
+        @DisplayName("크루가 이미 꽉 찬 경우, OVER_CREW_MEMBER_COUNT 예외가 발생한다.")
+        void throwOverCrewMemberCountException_whenJoiningFullCrew() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+            crew.joinMember(2L);
+            crew.joinMember(3L);
+            crew.joinMember(4L);
+            crew.joinMember(5L);
+            crew.joinMember(6L);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(7L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_MEMBER_COUNT));
+        }
+    }
+
+    @Nested
+    @DisplayName("크루원 추방 시,")
+    class Ban {
+        @Test
+        @DisplayName("크루원이 존재하지 않으면, NOT_FOUND 예외가 발생한다.")
+        void throwNotFoundException_whenBanningNonExistentMember() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.banMember(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("크루원 추방 후, 크루원 수가 감소한다.")
+        void decrementActiveMemberCount_whenBanningMember() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+            crew.joinMember(2L);
+            crew.joinMember(3L);
+
+            crew.banMember(2L);
+
+            assertThat(crew.getActiveMemberCount()).isEqualTo(2L);
+        }
+    }
+
+    @Nested
+    @DisplayName("크루원 탈퇴 시,")
+    class Leave {
+
+        @Test
+        @DisplayName("크루원이 존재하지 않으면, NOT_FOUND 예외가 발생한다.")
+        void throwNotFoundException_whenLeavingNonExistentMember() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+
+            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.leaveMember(2L));
+
+            assertThat(thrown)
+                    .usingRecursiveComparison()
+                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("크루원 탈퇴 후, 크루원 수가 감소한다.")
+        void decrementActiveMemberCount_whenLeavingMember() {
+            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+            Code code = new Code("ABC123");
+            Crew crew = Crew.of(command, code);
+            crew.joinMember(2L);
+            crew.joinMember(3L);
+
+            crew.leaveMember(2L);
+
+            assertThat(crew.getActiveMemberCount()).isEqualTo(2L);
+        }
+    }
+
+    @Test
+    @DisplayName("크루의 리더를 조회한다.")
+    void getLeader() {
+        CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+        Code code = new Code("ABC123");
+        Crew crew = Crew.of(command, code);
+        crew.joinMember(2L);
+        crew.joinMember(3L);
+        crew.joinMember(4L);
+
+        CrewMember leader = crew.getLeader();
+
+        assertThat(leader.getRole()).isEqualTo(CrewMember.Role.LEADER);
+        assertThat(leader.getMemberId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("크루의 멤버를 조회한다.")
+    void getMember() {
+        CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+        Code code = new Code("ABC123");
+        Crew crew = Crew.of(command, code);
+        crew.joinMember(2L);
+        crew.joinMember(3L);
+
+        CrewMember member = crew.getMember(2L);
+
+        assertThat(member.getMemberId()).isEqualTo(2L);
+        assertThat(member.getRole()).isEqualTo(CrewMember.Role.MEMBER);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #11 

## 📌 작업 내용 및 특이사항
- 크루 생성
- 크루 참여
- 크루 목록 조회
- 크루 상세 조회
- 크루 탈퇴
- 크루원 목록 조회

## 📝 참고사항
- 유저 인증은 추후 필터를 통해 수정될 예정입니다.
- 아직 개발되지 않은 서비스 기능이 필요한 경우, TODO로 남기고 하드 코딩으로 하였습니다.

## 📚 기타
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Join a crew using an invite code.
  - View your crews list.
  - See detailed crew info (leader, notice, active member count, code).
  - Leave a crew; leaders must delegate before leaving.
  - View current crew members.

- Improvements
  - Member counts now reflect active members only.
  - Limits enforced: up to 6 members per crew; each user can be in up to 5 crews.
  - Clearer error messages for not found, membership, bans, capacity, and leadership rules.

- Documentation
  - API documentation updated for new crew endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->