### PR TITLE
Feat: 런닝 세션 API 및 실시간 위치 공유 기능 구현 

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -29,7 +29,7 @@ jobs:
       REFRESH_HASH_ALGORITHM: ${{ secrets.REFRESH_HASH_ALGORITHM }}
       REFRESH_HASH_MODE: ${{ secrets.REFRESH_HASH_MODE }}
       REFRESH_TOKEN_PEPPER: ${{ secrets.REFRESH_TOKEN_PEPPER }}
-      SIGNUP_TTL : ${{ secrets.SIGNUP_TTL }}
+      SIGNUP_TTL: ${{ secrets.SIGNUP_TTL }}
 
 
     steps:
@@ -59,6 +59,6 @@ jobs:
         shell: bash
 
       - name: Gradle 테스트
-        run: ./gradlew clean build test
+        run: ./gradlew clean build test -i --stacktrace
         env:
           SPRING_PROFILES_ACTIVE: prod

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -59,6 +59,6 @@ jobs:
         shell: bash
 
       - name: Gradle 테스트
-        run: ./gradlew clean build test -i --stacktrace
+        run: ./gradlew clean build test
         env:
           SPRING_PROFILES_ACTIVE: prod

--- a/src/main/java/com/runky/auth/config/props/SignupTokenProperties.java
+++ b/src/main/java/com/runky/auth/config/props/SignupTokenProperties.java
@@ -7,7 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import jakarta.validation.constraints.Min;
 
 @ConfigurationProperties(prefix = "runky.security.signup-token")
-public record SignupTokenProperties(@Min(1) long ttlMinutes) {
+public record SignupTokenProperties(@Min(1) Long ttlMinutes) {
 	public Duration ttl() {
 		return Duration.ofMinutes(ttlMinutes);
 	}

--- a/src/main/java/com/runky/running/api/RunningApiSpec.java
+++ b/src/main/java/com/runky/running/api/RunningApiSpec.java
@@ -1,0 +1,28 @@
+package com.runky.running.api;
+
+import com.runky.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Running API", description = "Runky Running API입니다.")
+public interface RunningApiSpec {
+
+	@Operation(summary = "런닝 시작", description = "런닝 세션을 시작하고, 실시간 위치를 전송할 WebSocket 주소를 반환합니다.")
+	@Parameter(name = "X-USER-ID", description = "사용자 ID", required = true, in = ParameterIn.HEADER, schema = @Schema(type = "integer", format = "int64"))
+	ApiResponse<RunningResponse.Start> start(
+		Long userId
+	);
+
+	@Operation(summary = "런닝 종료", description = "런닝을 종료하고 전체 기록을 저장합니다.")
+	@Parameter(name = "X-USER-ID", description = "사용자 ID", required = true, in = ParameterIn.HEADER, schema = @Schema(type = "integer", format = "int64"))
+	ApiResponse<RunningResponse.End> end(
+		Long userId,
+		@Schema(description = "종료할 런닝 ID") Long runningId,
+		@Schema(description = "런닝 요약 및 트랙 정보") RunningRequest.End request
+	);
+}
+

--- a/src/main/java/com/runky/running/api/RunningController.java
+++ b/src/main/java/com/runky/running/api/RunningController.java
@@ -3,6 +3,7 @@ package com.runky.running.api;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,8 +22,8 @@ public class RunningController {
 	private final RunningFacade runningFacade;
 
 	@PostMapping("/start")
-	public ApiResponse<RunningResponse.Start> start(@RequestBody RunningRequest.Start req) {
-		RunningResult.Start result = runningFacade.start(new RunningCriteria.Start(req.runnerId()));
+	public ApiResponse<RunningResponse.Start> start(@RequestHeader("X-USER-ID") Long userId) {
+		RunningResult.Start result = runningFacade.start(new RunningCriteria.Start(userId));
 
 		String publish = "/app/runnings/" + result.runningId() + "/location";
 
@@ -31,8 +32,9 @@ public class RunningController {
 	}
 
 	@PostMapping("/{runningId}/end")
-	public ApiResponse<RunningResponse.End> end(@PathVariable Long runningId, @RequestBody RunningRequest.End request) {
-		RunningCriteria.End criteria = request.toCriteria(runningId);
+	public ApiResponse<RunningResponse.End> end(@RequestHeader("X-USER-ID") Long userId, @PathVariable Long runningId,
+		@RequestBody RunningRequest.End request) {
+		RunningCriteria.End criteria = request.toCriteria(userId, runningId);
 		RunningResult.End result = runningFacade.end(criteria);
 
 		RunningResponse.End response = RunningResponse.End.from(result);

--- a/src/main/java/com/runky/running/api/RunningController.java
+++ b/src/main/java/com/runky/running/api/RunningController.java
@@ -17,10 +17,11 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/runnings")
 @RequiredArgsConstructor
-public class RunningController {
+public class RunningController implements RunningApiSpec {
 
 	private final RunningFacade runningFacade;
 
+	@Override
 	@PostMapping("/start")
 	public ApiResponse<RunningResponse.Start> start(@RequestHeader("X-USER-ID") Long userId) {
 		RunningResult.Start result = runningFacade.start(new RunningCriteria.Start(userId));
@@ -31,6 +32,7 @@ public class RunningController {
 		return ApiResponse.success(response);
 	}
 
+	@Override
 	@PostMapping("/{runningId}/end")
 	public ApiResponse<RunningResponse.End> end(@RequestHeader("X-USER-ID") Long userId, @PathVariable Long runningId,
 		@RequestBody RunningRequest.End request) {

--- a/src/main/java/com/runky/running/api/RunningController.java
+++ b/src/main/java/com/runky/running/api/RunningController.java
@@ -1,0 +1,41 @@
+package com.runky.running.api;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.runky.global.response.ApiResponse;
+import com.runky.running.application.RunningCriteria;
+import com.runky.running.application.RunningFacade;
+import com.runky.running.application.RunningResult;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/runnings")
+@RequiredArgsConstructor
+public class RunningController {
+
+	private final RunningFacade runningFacade;
+
+	@PostMapping("/start")
+	public ApiResponse<RunningResponse.Start> start(@RequestBody RunningRequest.Start req) {
+		RunningResult.Start result = runningFacade.start(new RunningCriteria.Start(req.runnerId()));
+
+		String publish = "/app/runnings/" + result.runningId() + "/location";
+
+		RunningResponse.Start response = RunningResponse.Start.from(publish, result);
+		return ApiResponse.success(response);
+	}
+
+	@PostMapping("/{runningId}/end")
+	public ApiResponse<RunningResponse.End> end(@PathVariable Long runningId, @RequestBody RunningRequest.End request) {
+		RunningCriteria.End criteria = request.toCriteria(runningId);
+		RunningResult.End result = runningFacade.end(criteria);
+
+		RunningResponse.End response = RunningResponse.End.from(result);
+		return ApiResponse.success(response);
+	}
+}

--- a/src/main/java/com/runky/running/api/RunningLocationWsApiSpec.java
+++ b/src/main/java/com/runky/running/api/RunningLocationWsApiSpec.java
@@ -1,0 +1,23 @@
+package com.runky.running.api;
+
+/**
+ * 실시간 런닝 위치 공유 WebSocket API 명세
+ */
+public interface RunningLocationWsApiSpec {
+
+	/**
+	 * 클라이언트로부터 실시간 위치 정보를 수신하여 해당 런닝 세션을 구독하는 모든 클라이언트에게 브로드캐스팅합니다.
+	 * <p>
+	 * - <b>Publish Destination</b>: /app/runnings/{runningId}/location
+	 * <p>
+	 * - <b>Subscribe Destination</b>: /topic/runnings/{runningId}
+	 *
+	 * @param runningId 런닝 세션 ID
+	 * @param payload   위치 정보 메시지 (runnerId, x, y, timestamp)
+	 * @return 브로드캐스팅될 RoomEvent 객체
+	 */
+	RunningLocationWsController.RoomEvent publish(
+		Long runningId,
+		RunningLocationWsController.LocationMessage payload
+	);
+}

--- a/src/main/java/com/runky/running/api/RunningLocationWsController.java
+++ b/src/main/java/com/runky/running/api/RunningLocationWsController.java
@@ -1,0 +1,23 @@
+package com.runky.running.api;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class RunningLocationWsController {
+
+	@MessageMapping("/runnings/{runningId}/location")
+	@SendTo("/topic/runnings/{runningId}")
+	public RoomEvent publish(@DestinationVariable Long runningId, @Payload LocationMessage payload) {
+		return new RoomEvent("LOCATION", payload.runnerId(), payload.x(), payload.y(), payload.timestamp());
+	}
+
+	public record LocationMessage(Long runnerId, double x, double y, long timestamp) {
+	}
+
+	public record RoomEvent(String type, Long runnerId, Double x, Double y, long timestamp) {
+	}
+}

--- a/src/main/java/com/runky/running/api/RunningLocationWsController.java
+++ b/src/main/java/com/runky/running/api/RunningLocationWsController.java
@@ -7,7 +7,7 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.stereotype.Controller;
 
 @Controller
-public class RunningLocationWsController {
+public class RunningLocationWsController implements RunningLocationWsApiSpec {
 
 	@MessageMapping("/runnings/{runningId}/location")
 	@SendTo("/topic/runnings/{runningId}")

--- a/src/main/java/com/runky/running/api/RunningRequest.java
+++ b/src/main/java/com/runky/running/api/RunningRequest.java
@@ -1,0 +1,49 @@
+package com.runky.running.api;
+
+import com.runky.running.application.RunningCriteria;
+
+public sealed interface RunningRequest {
+
+	record Start(Long runnerId) implements RunningRequest {
+	}
+
+	record End(
+		Long runnerId,
+		Summary summary,
+		Track track
+	) implements RunningRequest {
+		RunningCriteria.End toCriteria(Long runningId) {
+			return new RunningCriteria.End(
+				runningId,
+				runnerId,
+				summary.totalDistanceM,
+				summary.durationS,
+				summary.avgSpeedMPS,
+				track.format,
+				track.points,
+				track.pointCount
+			);
+		}
+
+		record Summary(
+			Double totalDistanceM,
+			Long durationS,
+			Double avgSpeedMPS
+		) {
+		}
+
+		record Track(
+			String format,
+			String points,
+			int pointCount
+		) {
+		}
+
+		record Point(
+			Double lat,
+			Double lng,
+			Long timestamp
+		) {
+		}
+	}
+}

--- a/src/main/java/com/runky/running/api/RunningRequest.java
+++ b/src/main/java/com/runky/running/api/RunningRequest.java
@@ -12,8 +12,8 @@ public sealed interface RunningRequest {
 			return new RunningCriteria.End(
 				runnerId,
 				runningId,
-				summary.totalDistanceM,
-				summary.durationS,
+				summary.totalDistanceMinutes,
+				summary.durationSeconds,
 				summary.avgSpeedMPS,
 				track.format,
 				track.points,
@@ -22,8 +22,8 @@ public sealed interface RunningRequest {
 		}
 
 		record Summary(
-			Double totalDistanceM,
-			Long durationS,
+			Double totalDistanceMinutes,
+			Long durationSeconds,
 			Double avgSpeedMPS
 		) {
 		}

--- a/src/main/java/com/runky/running/api/RunningRequest.java
+++ b/src/main/java/com/runky/running/api/RunningRequest.java
@@ -4,18 +4,14 @@ import com.runky.running.application.RunningCriteria;
 
 public sealed interface RunningRequest {
 
-	record Start(Long runnerId) implements RunningRequest {
-	}
-
 	record End(
-		Long runnerId,
 		Summary summary,
 		Track track
 	) implements RunningRequest {
-		RunningCriteria.End toCriteria(Long runningId) {
+		RunningCriteria.End toCriteria(Long runnerId, Long runningId) {
 			return new RunningCriteria.End(
-				runningId,
 				runnerId,
+				runningId,
 				summary.totalDistanceM,
 				summary.durationS,
 				summary.avgSpeedMPS,

--- a/src/main/java/com/runky/running/api/RunningResponse.java
+++ b/src/main/java/com/runky/running/api/RunningResponse.java
@@ -1,0 +1,23 @@
+package com.runky.running.api;
+
+import java.time.LocalDateTime;
+
+import com.runky.running.application.RunningResult;
+
+public sealed interface RunningResponse {
+
+	record Start(Long runningId, Long runnerId, String status, String publishDestination, LocalDateTime startedAt)
+		implements RunningResponse {
+		static RunningResponse.Start from(String pub, RunningResult.Start result) {
+			return new Start(result.runningId(), result.runnerId(), result.status(), pub, result.startedAt());
+		}
+	}
+
+	record End(Long runningId, Long runnerId, String string, LocalDateTime startedAt, LocalDateTime endedAt)
+		implements RunningResponse {
+		static RunningResponse.End from(RunningResult.End result) {
+			return new End(result.runningId(), result.runnerId(), result.status(), result.startedAt(),
+				result.endedAt());
+		}
+	}
+}

--- a/src/main/java/com/runky/running/application/RunningCriteria.java
+++ b/src/main/java/com/runky/running/application/RunningCriteria.java
@@ -15,8 +15,8 @@ public sealed interface RunningCriteria {
 	record End(
 		Long runningId,
 		Long runnerId,
-		Double totalDistanceM,
-		Long durationS,
+		Double totalDistanceMinutes,
+		Long durationSeconds,
 		Double avgSpeedMPS,
 		String format,
 		String points,
@@ -25,7 +25,7 @@ public sealed interface RunningCriteria {
 	) implements RunningCriteria {
 		RunningCommand.End toCommand() {
 			return new RunningCommand.End(
-				runningId, runnerId, totalDistanceM, durationS, avgSpeedMPS, format, points, pointCount
+				runningId, runnerId, totalDistanceMinutes, durationSeconds, avgSpeedMPS, format, points, pointCount
 			);
 		}
 	}

--- a/src/main/java/com/runky/running/application/RunningCriteria.java
+++ b/src/main/java/com/runky/running/application/RunningCriteria.java
@@ -1,0 +1,32 @@
+package com.runky.running.application;
+
+import com.runky.running.domain.RunningCommand;
+
+public sealed interface RunningCriteria {
+
+	record Start(
+		Long runnerId
+	) {
+		RunningCommand.Start toCommand() {
+			return new RunningCommand.Start(runnerId);
+		}
+	}
+
+	record End(
+		Long runningId,
+		Long runnerId,
+		Double totalDistanceM,
+		Long durationS,
+		Double avgSpeedMPS,
+		String format,
+		String points,
+		int pointCount
+
+	) implements RunningCriteria {
+		RunningCommand.End toCommand() {
+			return new RunningCommand.End(
+				runningId, runnerId, totalDistanceM, durationS, avgSpeedMPS, format, points, pointCount
+			);
+		}
+	}
+}

--- a/src/main/java/com/runky/running/application/RunningFacade.java
+++ b/src/main/java/com/runky/running/application/RunningFacade.java
@@ -1,0 +1,28 @@
+package com.runky.running.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.runky.running.domain.RunningInfo;
+import com.runky.running.domain.RunningService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RunningFacade {
+	private final RunningService runningService;
+
+	@Transactional
+	public RunningResult.Start start(RunningCriteria.Start criteria) {
+		RunningInfo.Start info = runningService.start(criteria.toCommand());
+		return RunningResult.Start.from(info);
+	}
+
+	@Transactional
+	public RunningResult.End end(RunningCriteria.End criteria) {
+		RunningInfo.End info = runningService.end(criteria.toCommand());
+		return RunningResult.End.from(info);
+	}
+
+}

--- a/src/main/java/com/runky/running/application/RunningResult.java
+++ b/src/main/java/com/runky/running/application/RunningResult.java
@@ -1,0 +1,34 @@
+package com.runky.running.application;
+
+import java.time.LocalDateTime;
+
+import com.runky.running.domain.RunningInfo;
+
+public sealed interface RunningResult {
+
+	record Start(Long runningId, Long runnerId, String status, LocalDateTime startedAt) implements RunningResult {
+		public static RunningResult.Start from(RunningInfo.Start info) {
+			return new RunningResult.Start(
+				info.runningId(),
+				info.runnerId(),
+				info.status(),
+				info.startedAt()
+			);
+		}
+	}
+
+	record End(Long runningId, Long runnerId, String status, LocalDateTime startedAt, LocalDateTime endedAt
+	) implements RunningResult {
+
+		public static RunningResult.End from(RunningInfo.End info) {
+			return new RunningResult.End(
+				info.runningId(),
+				info.runnerId(),
+				info.status(),
+				info.startedAt(),
+				info.endedAt()
+			);
+		}
+	}
+
+}

--- a/src/main/java/com/runky/running/domain/Running.java
+++ b/src/main/java/com/runky/running/domain/Running.java
@@ -1,0 +1,80 @@
+package com.runky.running.domain;
+
+import java.time.LocalDateTime;
+
+import com.runky.global.error.GlobalException;
+import com.runky.running.error.RunningErrorCode;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "runnings")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Running {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "runner_id", nullable = false)
+	private Long runnerId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 16)
+	private Status status; // RUNNING, FINISHED
+
+	@Column(name = "started_at", nullable = false)
+	private LocalDateTime startedAt;
+
+	@Column(name = "ended_at", nullable = true)
+	private LocalDateTime endedAt;
+
+	// 요약치(종료 시 세팅)
+	@Column(name = "total_distance_m")
+	private Double totalDistanceM;
+
+	@Column(name = "duration_ms")
+	private Long durationS;
+
+	@Column(name = "avg_speed_mps")
+	private Double avgSpeedMPS;
+
+	public static Running start(Long runningId, LocalDateTime now) {
+		return Running.builder()
+			.runnerId(runningId)
+			.status(Status.RUNNING)
+			.startedAt(now)
+			.build();
+	}
+
+	public boolean isActive() {
+		return this.status == Status.RUNNING && this.endedAt == null;
+	}
+
+	public void finish(double totalDistanceM, long durationS, Double avgSpeedMps) {
+		if (this.status != Status.RUNNING) {
+			throw new GlobalException(RunningErrorCode.NOT_ACTIVE_RUNNING);
+		}
+		this.endedAt = LocalDateTime.now();
+		this.status = Status.FINISHED;
+		this.totalDistanceM = totalDistanceM;
+		this.durationS = durationS;
+		this.avgSpeedMPS = avgSpeedMps;
+	}
+
+	public enum Status {RUNNING, FINISHED}
+}

--- a/src/main/java/com/runky/running/domain/Running.java
+++ b/src/main/java/com/runky/running/domain/Running.java
@@ -43,12 +43,11 @@ public class Running {
 	@Column(name = "ended_at", nullable = true)
 	private LocalDateTime endedAt;
 
-	// 요약치(종료 시 세팅)
-	@Column(name = "total_distance_m")
-	private Double totalDistanceM;
+	@Column(name = "total_distance_minutes")
+	private Double totalDistanceMinutes;
 
-	@Column(name = "duration_ms")
-	private Long durationS;
+	@Column(name = "duration_seconds")
+	private Long durationSeconds;
 
 	@Column(name = "avg_speed_mps")
 	private Double avgSpeedMPS;
@@ -65,14 +64,14 @@ public class Running {
 		return this.status == Status.RUNNING && this.endedAt == null;
 	}
 
-	public void finish(double totalDistanceM, long durationS, Double avgSpeedMps) {
+	public void finish(double totalDistanceMinutes, long durationSeconds, Double avgSpeedMps) {
 		if (this.status != Status.RUNNING) {
 			throw new GlobalException(RunningErrorCode.NOT_ACTIVE_RUNNING);
 		}
 		this.endedAt = LocalDateTime.now();
 		this.status = Status.FINISHED;
-		this.totalDistanceM = totalDistanceM;
-		this.durationS = durationS;
+		this.totalDistanceMinutes = totalDistanceMinutes;
+		this.durationSeconds = durationSeconds;
 		this.avgSpeedMPS = avgSpeedMps;
 	}
 

--- a/src/main/java/com/runky/running/domain/RunningCommand.java
+++ b/src/main/java/com/runky/running/domain/RunningCommand.java
@@ -9,8 +9,8 @@ public sealed interface RunningCommand {
 	record End(
 		Long runningId,
 		Long runnerId,
-		Double totalDistanceM,
-		Long durationS,
+		Double totalDistanceMinutes,
+		Long durationSeconds,
 		Double avgSpeedMPS,
 		String format,
 		String points,

--- a/src/main/java/com/runky/running/domain/RunningCommand.java
+++ b/src/main/java/com/runky/running/domain/RunningCommand.java
@@ -1,0 +1,20 @@
+package com.runky.running.domain;
+
+public sealed interface RunningCommand {
+	record Start(
+		Long runnerId
+	) implements RunningCommand {
+	}
+
+	record End(
+		Long runningId,
+		Long runnerId,
+		Double totalDistanceM,
+		Long durationS,
+		Double avgSpeedMPS,
+		String format,
+		String points,
+		int pointCount
+	) implements RunningCommand {
+	}
+}

--- a/src/main/java/com/runky/running/domain/RunningInfo.java
+++ b/src/main/java/com/runky/running/domain/RunningInfo.java
@@ -1,0 +1,21 @@
+package com.runky.running.domain;
+
+import java.time.LocalDateTime;
+
+public sealed interface RunningInfo {
+
+	record Start(Long runningId, Long runnerId, String status, LocalDateTime startedAt) implements RunningInfo {
+		static RunningInfo.Start from(Running running) {
+			return new RunningInfo.Start(
+				running.getId(),
+				running.getRunnerId(),
+				running.getStatus().toString(),
+				running.getStartedAt()
+			);
+		}
+	}
+
+	record End(Long runningId, Long runnerId, String status, LocalDateTime startedAt, LocalDateTime endedAt)
+		implements RunningInfo {
+	}
+}

--- a/src/main/java/com/runky/running/domain/RunningRepository.java
+++ b/src/main/java/com/runky/running/domain/RunningRepository.java
@@ -1,0 +1,11 @@
+package com.runky.running.domain;
+
+import java.util.Optional;
+
+public interface RunningRepository {
+	boolean existsByRunnerIdAndEndedAtIsNull(Long runnerId);
+
+	Optional<Running> findByIdAndRunnerId(Long id, Long runnerId);
+
+	Running save(Running running);
+}

--- a/src/main/java/com/runky/running/domain/RunningService.java
+++ b/src/main/java/com/runky/running/domain/RunningService.java
@@ -38,7 +38,7 @@ public class RunningService {
 			throw new GlobalException(RunningErrorCode.NOT_ACTIVE_RUNNING);
 		}
 
-		running.finish(command.totalDistanceM(), command.durationS(), command.avgSpeedMPS());
+		running.finish(command.totalDistanceMinutes(), command.durationSeconds(), command.avgSpeedMPS());
 		runningRepository.save(running);
 
 		if (trackRepository.existsByRunningId(command.runningId())) {

--- a/src/main/java/com/runky/running/domain/RunningService.java
+++ b/src/main/java/com/runky/running/domain/RunningService.java
@@ -1,0 +1,59 @@
+package com.runky.running.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.runky.global.error.GlobalException;
+import com.runky.running.error.RunningErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RunningService {
+
+	private final RunningRepository runningRepository;
+	private final ApplicationEventPublisher events;
+	private final RunningTrackRepository trackRepository;
+
+	@Transactional
+	public RunningInfo.Start start(RunningCommand.Start command) {
+		if (runningRepository.existsByRunnerIdAndEndedAtIsNull(command.runnerId())) {
+			throw new GlobalException(RunningErrorCode.NOT_FOUND_RUNNING);
+		}
+
+		Running running = runningRepository.save(Running.start(command.runnerId(), LocalDateTime.now()));
+		return RunningInfo.Start.from(running);
+	}
+
+	@Transactional
+	public RunningInfo.End end(RunningCommand.End command) {
+		Running running = runningRepository.findByIdAndRunnerId(command.runningId(), command.runnerId())
+			.orElseThrow(() -> new GlobalException(RunningErrorCode.NOT_FOUND_RUNNING));
+
+		if (!running.isActive()) {
+			throw new GlobalException(RunningErrorCode.NOT_ACTIVE_RUNNING);
+		}
+
+		running.finish(command.totalDistanceM(), command.durationS(), command.avgSpeedMPS());
+		runningRepository.save(running);
+
+		if (trackRepository.existsByRunningId(command.runningId())) {
+			throw new GlobalException(RunningErrorCode.TRACK_ALREADY_EXISTS);
+		}
+
+		RunningTrack runningTrack = new RunningTrack(
+			running,
+			command.format(),
+			command.points(),
+			command.pointCount()
+		);
+		trackRepository.save(runningTrack);
+
+		return new RunningInfo.End(running.getId(), running.getRunnerId(), running.getStatus().toString(),
+			running.getStartedAt(), running.getEndedAt());
+	}
+}

--- a/src/main/java/com/runky/running/domain/RunningTrack.java
+++ b/src/main/java/com/runky/running/domain/RunningTrack.java
@@ -1,0 +1,48 @@
+package com.runky.running.domain;
+
+import com.runky.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "running_tracks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RunningTrack extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "running_id", nullable = false)
+	private Running running;
+
+	@Column(name = "format", nullable = false)
+	private String format;
+
+	@Column(columnDefinition = "TEXT", name = "points", nullable = false)
+	private String points;
+
+	@Column(name = "point_count", nullable = false)
+	private int pointCount;
+
+	@Builder
+	public RunningTrack(final Running running, final String points, final String format, final int pointCount) {
+		this.running = running;
+		this.points = points;
+		this.format = format;
+		this.pointCount = pointCount;
+	}
+}

--- a/src/main/java/com/runky/running/domain/RunningTrackRepository.java
+++ b/src/main/java/com/runky/running/domain/RunningTrackRepository.java
@@ -1,0 +1,8 @@
+package com.runky.running.domain;
+
+public interface RunningTrackRepository {
+	boolean existsByRunningId(Long runningId);
+
+	void save(RunningTrack runningTrack);
+
+}

--- a/src/main/java/com/runky/running/error/RunningErrorCode.java
+++ b/src/main/java/com/runky/running/error/RunningErrorCode.java
@@ -1,0 +1,35 @@
+package com.runky.running.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.runky.global.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RunningErrorCode implements ErrorCode {
+	/* R1xx: Running 상태/조회 */
+	NOT_FOUND_RUNNING(HttpStatus.NOT_FOUND, "R101", "런닝을 찾을 수 없습니다."),
+	ALREADY_ACTIVE_RUNNING(HttpStatus.CONFLICT, "R102", "이미 진행 중인 런닝이 있습니다."),
+	NOT_ACTIVE_RUNNING(HttpStatus.CONFLICT, "R103", "시작 상태가 아니므로 종료할 수 없습니다."),
+
+	/* R2xx: Running Track 저장/포맷 */
+	TRACK_ALREADY_EXISTS(HttpStatus.CONFLICT, "R201", "이미 트랙이 저장되어 있습니다."),
+	INVALID_TRACK_FORMAT(HttpStatus.BAD_REQUEST, "R202", "지원하지 않는 트랙 포맷입니다."),
+	EMPTY_TRACK_POINTS(HttpStatus.BAD_REQUEST, "R203", "트랙 좌표가 비어있습니다."),
+	EXCESSIVE_TRACK_POINTS(HttpStatus.UNPROCESSABLE_ENTITY, "R204", "트랙 좌표 개수가 허용 범위를 초과했습니다."),
+
+	/* R3xx: 권한/입력 검증 */
+	FORBIDDEN_RUNNING_ACCESS(HttpStatus.FORBIDDEN, "R301", "해당 런닝에 접근 권한이 없습니다."),
+	INVALID_END_METRICS(HttpStatus.BAD_REQUEST, "R302", "종료 메트릭 값이 올바르지 않습니다."),
+
+	/* R9xx: 인프라/제약 위반/기타 */
+	UNIQUE_ACTIVE_CONSTRAINT_VIOLATED(HttpStatus.CONFLICT, "R901", "활성 런닝 중복 제약에 위배되었습니다."),
+	EVENT_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "R902", "이벤트 발행에 실패했습니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/runky/running/infra/RunningJpaRepository.java
+++ b/src/main/java/com/runky/running/infra/RunningJpaRepository.java
@@ -1,0 +1,14 @@
+package com.runky.running.infra;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.runky.running.domain.Running;
+
+public interface RunningJpaRepository extends JpaRepository<Running, Long> {
+	boolean existsByRunnerIdAndEndedAtIsNull(Long runnerId);
+
+	Optional<Running> findByIdAndRunnerId(Long id, Long runnerId);
+
+}

--- a/src/main/java/com/runky/running/infra/RunningRepositoryImpl.java
+++ b/src/main/java/com/runky/running/infra/RunningRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.runky.running.infra;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.runky.running.domain.Running;
+import com.runky.running.domain.RunningRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RunningRepositoryImpl implements RunningRepository {
+	private final RunningJpaRepository jpaRepository;
+
+	@Override
+	public boolean existsByRunnerIdAndEndedAtIsNull(final Long runnerId) {
+		return jpaRepository.existsByRunnerIdAndEndedAtIsNull(runnerId);
+	}
+
+	@Override
+	public Optional<Running> findByIdAndRunnerId(final Long id, final Long runnerId) {
+		return jpaRepository.findByIdAndRunnerId(id, runnerId);
+	}
+
+	@Override
+	public Running save(final Running running) {
+		jpaRepository.save(running);
+		return running;
+	}
+}

--- a/src/main/java/com/runky/running/infra/RunningTrackJpaRepository.java
+++ b/src/main/java/com/runky/running/infra/RunningTrackJpaRepository.java
@@ -1,0 +1,9 @@
+package com.runky.running.infra;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.runky.running.domain.RunningTrack;
+
+public interface RunningTrackJpaRepository extends JpaRepository<RunningTrack, Long> {
+	boolean existsByRunningId(Long runningId);
+}

--- a/src/main/java/com/runky/running/infra/RunningTrackRepositoryImpl.java
+++ b/src/main/java/com/runky/running/infra/RunningTrackRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.runky.running.infra;
+
+import org.springframework.stereotype.Repository;
+
+import com.runky.running.domain.RunningTrack;
+import com.runky.running.domain.RunningTrackRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RunningTrackRepositoryImpl implements RunningTrackRepository {
+	private final RunningTrackJpaRepository jpaRepository;
+
+	@Override
+	public boolean existsByRunningId(final Long runningId) {
+		return jpaRepository.existsByRunningId(runningId);
+	}
+
+	@Override
+	public void save(final RunningTrack runningTrack) {
+		jpaRepository.save(runningTrack);
+	}
+}

--- a/src/test/java/com/runky/crew/api/CrewApiE2ETest.java
+++ b/src/test/java/com/runky/crew/api/CrewApiE2ETest.java
@@ -25,348 +25,348 @@ import org.springframework.http.ResponseEntity;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class CrewApiE2ETest {
-    private final TestRestTemplate testRestTemplate;
-    private final DatabaseCleanUp databaseCleanUp;
-    private final CrewRepository crewRepository;
+	private final TestRestTemplate testRestTemplate;
+	private final DatabaseCleanUp databaseCleanUp;
+	private final CrewRepository crewRepository;
 
-    @Autowired
-    public CrewApiE2ETest(TestRestTemplate testRestTemplate, DatabaseCleanUp databaseCleanUp,
-                          CrewRepository crewRepository) {
-        this.testRestTemplate = testRestTemplate;
-        this.databaseCleanUp = databaseCleanUp;
-        this.crewRepository = crewRepository;
-    }
+	@Autowired
+	public CrewApiE2ETest(TestRestTemplate testRestTemplate, DatabaseCleanUp databaseCleanUp,
+		CrewRepository crewRepository) {
+		this.testRestTemplate = testRestTemplate;
+		this.databaseCleanUp = databaseCleanUp;
+		this.crewRepository = crewRepository;
+	}
 
-    @AfterEach
-    void tearDown() {
-        databaseCleanUp.truncateAllTables();
-    }
+	@AfterEach
+	void tearDown() {
+		databaseCleanUp.truncateAllTables();
+	}
 
-    @Nested
-    @DisplayName("POST /api/crews")
-    class Create {
-        final String BASE_URL = "/api/crews";
+	@Nested
+	@DisplayName("POST /api/crews")
+	class Create {
+		final String BASE_URL = "/api/crews";
 
-        @Test
-        @DisplayName("크루를 생성한다.")
-        void createCrew() {
-            long userId = 1L;
-            crewRepository.save(CrewMemberCount.of(userId));
-            ParameterizedTypeReference<ApiResponse<CrewResponse.Create>> responseType = new ParameterizedTypeReference<>() {
-            };
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("X-USER-ID", String.valueOf(userId));
-            CrewRequest.Create request = new CrewRequest.Create("Test Crew");
+		@Test
+		@DisplayName("크루를 생성한다.")
+		void createCrew() {
+			long userId = 1L;
+			crewRepository.save(CrewMemberCount.of(userId));
+			ParameterizedTypeReference<ApiResponse<CrewResponse.Create>> responseType = new ParameterizedTypeReference<>() {
+			};
+			HttpHeaders httpHeaders = new HttpHeaders();
+			httpHeaders.add("X-USER-ID", String.valueOf(userId));
+			CrewRequest.Create request = new CrewRequest.Create("Test Crew");
 
-            ResponseEntity<ApiResponse<CrewResponse.Create>> response =
-                    testRestTemplate.exchange(BASE_URL, HttpMethod.POST, new HttpEntity<>(request, httpHeaders),
-                            responseType);
+			ResponseEntity<ApiResponse<CrewResponse.Create>> response =
+				testRestTemplate.exchange(BASE_URL, HttpMethod.POST, new HttpEntity<>(request, httpHeaders),
+					responseType);
 
-            Crew crew = crewRepository.findById(response.getBody().getResult().crewId()).orElseThrow();
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getResult().crewId()).isEqualTo(crew.getId());
-            assertThat(response.getBody().getResult().name()).isEqualTo(crew.getName());
-            assertThat(response.getBody().getResult().code()).isEqualTo(crew.getCode().value());
-        }
-    }
+			Crew crew = crewRepository.findById(response.getBody().getResult().crewId()).orElseThrow();
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getBody().getResult().crewId()).isEqualTo(crew.getId());
+			assertThat(response.getBody().getResult().name()).isEqualTo(crew.getName());
+			assertThat(response.getBody().getResult().code()).isEqualTo(crew.getCode().value());
+		}
+	}
 
-    @Nested
-    @DisplayName("POST /api/crews/join")
-    class Join {
-        final String BASE_URL = "/api/crews/join";
+	@Nested
+	@DisplayName("POST /api/crews/join")
+	class Join {
+		final String BASE_URL = "/api/crews/join";
 
-        @Test
-        @DisplayName("크루에 참여한다.")
-        void joinCrew() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Crew"), new Code("abc123"));
-            Crew savedCrew = crewRepository.save(crew);
-            Long userId = 2L;
-            crewRepository.save(CrewMemberCount.of(userId));
-            ParameterizedTypeReference<ApiResponse<CrewResponse.Join>> responseType = new ParameterizedTypeReference<>() {
-            };
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("X-USER-ID", String.valueOf(userId));
-            CrewRequest.Join request = new CrewRequest.Join(crew.getCode().value());
+		@Test
+		@DisplayName("크루에 참여한다.")
+		void joinCrew() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Crew"), new Code("abc123"));
+			Crew savedCrew = crewRepository.save(crew);
+			Long userId = 2L;
+			crewRepository.save(CrewMemberCount.of(userId));
+			ParameterizedTypeReference<ApiResponse<CrewResponse.Join>> responseType = new ParameterizedTypeReference<>() {
+			};
+			HttpHeaders httpHeaders = new HttpHeaders();
+			httpHeaders.add("X-USER-ID", String.valueOf(userId));
+			CrewRequest.Join request = new CrewRequest.Join(crew.getCode().value());
 
-            ResponseEntity<ApiResponse<CrewResponse.Join>> response =
-                    testRestTemplate.exchange(BASE_URL, HttpMethod.POST, new HttpEntity<>(request, httpHeaders),
-                            responseType);
+			ResponseEntity<ApiResponse<CrewResponse.Join>> response =
+				testRestTemplate.exchange(BASE_URL, HttpMethod.POST, new HttpEntity<>(request, httpHeaders),
+					responseType);
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getResult().crewId()).isEqualTo(savedCrew.getId());
-        }
-    }
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getBody().getResult().crewId()).isEqualTo(savedCrew.getId());
+		}
+	}
 
-    @Nested
-    @DisplayName("GET /api/crews")
-    class GetCrews {
-        final String BASE_URL = "/api/crews";
+	@Nested
+	@DisplayName("GET /api/crews")
+	class GetCrews {
+		final String BASE_URL = "/api/crews";
 
-        @Test
-        @DisplayName("사용자의 크루 목록을 조회한다.")
-        void getCrews() {
-            long userId = 1L;
-            crewRepository.save(CrewMemberCount.of(userId));
-            Crew crew1 = crewRepository.save(Crew.of(new CrewCommand.Create(userId, "Crew 1"), new Code("abc123")));
-            Crew crew2 = crewRepository.save(Crew.of(new CrewCommand.Create(userId, "Crew 2"), new Code("abc456")));
+		@Test
+		@DisplayName("사용자의 크루 목록을 조회한다.")
+		void getCrews() {
+			long userId = 1L;
+			crewRepository.save(CrewMemberCount.of(userId));
+			Crew crew1 = crewRepository.save(Crew.of(new CrewCommand.Create(userId, "Crew 1"), new Code("abc123")));
+			Crew crew2 = crewRepository.save(Crew.of(new CrewCommand.Create(userId, "Crew 2"), new Code("abc456")));
 
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("X-USER-ID", String.valueOf(userId));
-            ParameterizedTypeReference<ApiResponse<CrewResponse.Cards>> responseType = new ParameterizedTypeReference<>() {
-            };
+			HttpHeaders httpHeaders = new HttpHeaders();
+			httpHeaders.add("X-USER-ID", String.valueOf(userId));
+			ParameterizedTypeReference<ApiResponse<CrewResponse.Cards>> responseType = new ParameterizedTypeReference<>() {
+			};
 
-            ResponseEntity<ApiResponse<CrewResponse.Cards>> response =
-                    testRestTemplate.exchange(BASE_URL, HttpMethod.GET, new HttpEntity<>(httpHeaders), responseType);
+			ResponseEntity<ApiResponse<CrewResponse.Cards>> response =
+				testRestTemplate.exchange(BASE_URL, HttpMethod.GET, new HttpEntity<>(httpHeaders), responseType);
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getResult().crews()).hasSize(2);
-            assertThat(response.getBody().getResult().crews())
-                    .extracting("crewId")
-                    .containsExactlyInAnyOrder(crew1.getId(), crew2.getId());
-        }
-    }
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getBody().getResult().crews()).hasSize(2);
+			assertThat(response.getBody().getResult().crews())
+				.extracting("crewId")
+				.containsExactlyInAnyOrder(crew1.getId(), crew2.getId());
+		}
+	}
 
-    @Nested
-    @DisplayName("GET /api/crews/{crewId}")
-    class GetCrew {
-        final String BASE_URL = "/api/crews/{crewId}";
+	@Nested
+	@DisplayName("GET /api/crews/{crewId}")
+	class GetCrew {
+		final String BASE_URL = "/api/crews/{crewId}";
 
-        @Test
-        @DisplayName("크루의 상세 정보를 조회한다.")
-        void getCrew() {
-            long userId = 1L;
-            crewRepository.save(CrewMemberCount.of(userId));
-            Crew crew = crewRepository.save(Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123")));
+		@Test
+		@DisplayName("크루의 상세 정보를 조회한다.")
+		void getCrew() {
+			long userId = 1L;
+			crewRepository.save(CrewMemberCount.of(userId));
+			Crew crew = crewRepository.save(Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123")));
 
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("X-USER-ID", String.valueOf(userId));
-            ParameterizedTypeReference<ApiResponse<CrewResponse.Detail>> responseType = new ParameterizedTypeReference<>() {
-            };
+			HttpHeaders httpHeaders = new HttpHeaders();
+			httpHeaders.add("X-USER-ID", String.valueOf(userId));
+			ParameterizedTypeReference<ApiResponse<CrewResponse.Detail>> responseType = new ParameterizedTypeReference<>() {
+			};
 
-            ResponseEntity<ApiResponse<CrewResponse.Detail>> response =
-                    testRestTemplate.exchange(BASE_URL, HttpMethod.GET, new HttpEntity<>(httpHeaders), responseType,
-                            crew.getId());
+			ResponseEntity<ApiResponse<CrewResponse.Detail>> response =
+				testRestTemplate.exchange(BASE_URL, HttpMethod.GET, new HttpEntity<>(httpHeaders), responseType,
+					crew.getId());
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getResult().crewId()).isEqualTo(crew.getId());
-            assertThat(response.getBody().getResult().name()).isEqualTo(crew.getName());
-            assertThat(response.getBody().getResult().code()).isEqualTo(crew.getCode().value());
-            assertThat(response.getBody().getResult().memberCount()).isEqualTo(crew.getActiveMemberCount());
-            assertThat(response.getBody().getResult().notice()).isEqualTo(crew.getNotice());
-        }
-    }
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getBody().getResult().crewId()).isEqualTo(crew.getId());
+			assertThat(response.getBody().getResult().name()).isEqualTo(crew.getName());
+			assertThat(response.getBody().getResult().code()).isEqualTo(crew.getCode().value());
+			assertThat(response.getBody().getResult().memberCount()).isEqualTo(crew.getActiveMemberCount());
+			assertThat(response.getBody().getResult().notice()).isEqualTo(crew.getNotice());
+		}
+	}
 
-    @Nested
-    @DisplayName("DELETE /api/crews/{crewId}/members/me")
-    class Leave {
-        final String BASE_URL = "/api/crews/{crewId}/members/me";
+	@Nested
+	@DisplayName("DELETE /api/crews/{crewId}/members/me")
+	class Leave {
+		final String BASE_URL = "/api/crews/{crewId}/members/me";
 
-        @Test
-        @DisplayName("크루에 속한 사용자가 크루를 탈퇴한다.")
-        void leaveCrew() {
-            long userId = 1L;
-            crewRepository.save(CrewMemberCount.of(userId));
-            Crew crew = Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123"));
-            crew.joinMember(2L);
-            Crew savedCrew = crewRepository.save(crew);
-            CrewMemberCount crewMemberCount = CrewMemberCount.of(2L);
-            crewMemberCount.increment();
-            crewRepository.save(crewMemberCount);
+		@Test
+		@DisplayName("크루에 속한 사용자가 크루를 탈퇴한다.")
+		void leaveCrew() {
+			long userId = 1L;
+			crewRepository.save(CrewMemberCount.of(userId));
+			Crew crew = Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123"));
+			crew.joinMember(2L);
+			Crew savedCrew = crewRepository.save(crew);
+			CrewMemberCount crewMemberCount = CrewMemberCount.of(2L);
+			crewMemberCount.increment();
+			crewRepository.save(crewMemberCount);
 
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("X-USER-ID", String.valueOf(2L));
-            ParameterizedTypeReference<ApiResponse<CrewResponse.Leave>> responseType = new ParameterizedTypeReference<>() {
-            };
+			HttpHeaders httpHeaders = new HttpHeaders();
+			httpHeaders.add("X-USER-ID", String.valueOf(2L));
+			ParameterizedTypeReference<ApiResponse<CrewResponse.Leave>> responseType = new ParameterizedTypeReference<>() {
+			};
 
-            CrewRequest.Leave request = new CrewRequest.Leave(null);
-            ResponseEntity<ApiResponse<CrewResponse.Leave>> response =
-                    testRestTemplate.exchange(BASE_URL, HttpMethod.DELETE, new HttpEntity<>(request, httpHeaders),
-                            responseType,
-                            crew.getId());
+			CrewRequest.Leave request = new CrewRequest.Leave(null);
+			ResponseEntity<ApiResponse<CrewResponse.Leave>> response =
+				testRestTemplate.exchange(BASE_URL, HttpMethod.DELETE, new HttpEntity<>(request, httpHeaders),
+					responseType,
+					crew.getId());
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getResult().crewId()).isEqualTo(crew.getId());
-        }
-    }
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getBody().getResult().crewId()).isEqualTo(crew.getId());
+		}
+	}
 
-    @Nested
-    @DisplayName("GET /api/crews/{crewId}/members")
-    class GetCrewMembers {
-        final String BASE_URL = "/api/crews/{crewId}/members";
+	@Nested
+	@DisplayName("GET /api/crews/{crewId}/members")
+	class GetCrewMembers {
+		final String BASE_URL = "/api/crews/{crewId}/members";
 
-        @Test
-        @DisplayName("크루의 멤버 목록을 조회한다.")
-        void getCrewMembers() {
-            long userId = 1L;
-            crewRepository.save(CrewMemberCount.of(userId));
-            Crew crew = Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123"));
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-            crew.joinMember(4L);
-            crew.leaveMember(4L);
-            Crew savedCrew = crewRepository.save(crew);
+		@Test
+		@DisplayName("크루의 멤버 목록을 조회한다.")
+		void getCrewMembers() {
+			long userId = 1L;
+			crewRepository.save(CrewMemberCount.of(userId));
+			Crew crew = Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123"));
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+			crew.joinMember(4L);
+			crew.leaveMember(4L);
+			Crew savedCrew = crewRepository.save(crew);
 
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("X-USER-ID", String.valueOf(userId));
-            ParameterizedTypeReference<ApiResponse<CrewResponse.Members>> responseType = new ParameterizedTypeReference<>() {
-            };
+			HttpHeaders httpHeaders = new HttpHeaders();
+			httpHeaders.add("X-USER-ID", String.valueOf(userId));
+			ParameterizedTypeReference<ApiResponse<CrewResponse.Members>> responseType = new ParameterizedTypeReference<>() {
+			};
 
-            ResponseEntity<ApiResponse<CrewResponse.Members>> response =
-                    testRestTemplate.exchange(BASE_URL, HttpMethod.GET, new HttpEntity<>(httpHeaders), responseType,
-                            savedCrew.getId());
+			ResponseEntity<ApiResponse<CrewResponse.Members>> response =
+				testRestTemplate.exchange(BASE_URL, HttpMethod.GET, new HttpEntity<>(httpHeaders), responseType,
+					savedCrew.getId());
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getResult().members()).hasSize(3);
-        }
-    }
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getBody().getResult().members()).hasSize(3);
+		}
+	}
 
-    @Nested
-    @DisplayName("PATCH /api/crews/{crewId}/notice")
-    class UpdateNotice {
-        final String BASE_URL = "/api/crews/{crewId}/notice";
+	@Nested
+	@DisplayName("PATCH /api/crews/{crewId}/notice")
+	class UpdateNotice {
+		final String BASE_URL = "/api/crews/{crewId}/notice";
 
-        @Test
-        @DisplayName("크루의 공지사항을 업데이트한다.")
-        void updateNotice() {
-            long userId = 1L;
-            crewRepository.save(CrewMemberCount.of(userId));
-            Crew crew = Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123"));
-            Crew savedCrew = crewRepository.save(crew);
+		@Test
+		@DisplayName("크루의 공지사항을 업데이트한다.")
+		void updateNotice() {
+			long userId = 1L;
+			crewRepository.save(CrewMemberCount.of(userId));
+			Crew crew = Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123"));
+			Crew savedCrew = crewRepository.save(crew);
 
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("X-USER-ID", String.valueOf(userId));
-            ParameterizedTypeReference<ApiResponse<CrewResponse.Notice>> responseType = new ParameterizedTypeReference<>() {
-            };
+			HttpHeaders httpHeaders = new HttpHeaders();
+			httpHeaders.add("X-USER-ID", String.valueOf(userId));
+			ParameterizedTypeReference<ApiResponse<CrewResponse.Notice>> responseType = new ParameterizedTypeReference<>() {
+			};
 
-            CrewRequest.Notice request = new CrewRequest.Notice("New Notice");
-            ResponseEntity<ApiResponse<CrewResponse.Notice>> response =
-                    testRestTemplate.exchange(BASE_URL, HttpMethod.PATCH, new HttpEntity<>(request, httpHeaders),
-                            responseType, savedCrew.getId());
+			CrewRequest.Notice request = new CrewRequest.Notice("New Notice");
+			ResponseEntity<ApiResponse<CrewResponse.Notice>> response =
+				testRestTemplate.exchange(BASE_URL, HttpMethod.PATCH, new HttpEntity<>(request, httpHeaders),
+					responseType, savedCrew.getId());
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getResult().notice()).isEqualTo("New Notice");
-        }
-    }
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getBody().getResult().notice()).isEqualTo("New Notice");
+		}
+	}
 
-    @Nested
-    @DisplayName("PATCH /api/crews/{crewId}/name")
-    class UpdateCrewName {
-        final String BASE_URL = "/api/crews/{crewId}/name";
+	@Nested
+	@DisplayName("PATCH /api/crews/{crewId}/name")
+	class UpdateCrewName {
+		final String BASE_URL = "/api/crews/{crewId}/name";
 
-        @Test
-        @DisplayName("크루의 이름을 업데이트한다.")
-        void updateCrewName() {
-            long userId = 1L;
-            crewRepository.save(CrewMemberCount.of(userId));
-            Crew crew = Crew.of(new CrewCommand.Create(userId, "Old Crew Name"), new Code("abc123"));
-            Crew savedCrew = crewRepository.save(crew);
+		@Test
+		@DisplayName("크루의 이름을 업데이트한다.")
+		void updateCrewName() {
+			long userId = 1L;
+			crewRepository.save(CrewMemberCount.of(userId));
+			Crew crew = Crew.of(new CrewCommand.Create(userId, "Old Crew Name"), new Code("abc123"));
+			Crew savedCrew = crewRepository.save(crew);
 
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("X-USER-ID", String.valueOf(userId));
-            ParameterizedTypeReference<ApiResponse<CrewResponse.Name>> responseType = new ParameterizedTypeReference<>() {
-            };
+			HttpHeaders httpHeaders = new HttpHeaders();
+			httpHeaders.add("X-USER-ID", String.valueOf(userId));
+			ParameterizedTypeReference<ApiResponse<CrewResponse.Name>> responseType = new ParameterizedTypeReference<>() {
+			};
 
-            CrewRequest.Name request = new CrewRequest.Name("New Crew Name");
-            ResponseEntity<ApiResponse<CrewResponse.Name>> response =
-                    testRestTemplate.exchange(BASE_URL, HttpMethod.PATCH, new HttpEntity<>(request, httpHeaders),
-                            responseType, savedCrew.getId());
+			CrewRequest.Name request = new CrewRequest.Name("New Crew Name");
+			ResponseEntity<ApiResponse<CrewResponse.Name>> response =
+				testRestTemplate.exchange(BASE_URL, HttpMethod.PATCH, new HttpEntity<>(request, httpHeaders),
+					responseType, savedCrew.getId());
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getResult().name()).isEqualTo("New Crew Name");
-        }
-    }
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getBody().getResult().name()).isEqualTo("New Crew Name");
+		}
+	}
 
-    @Nested
-    @DisplayName("DELETE /api/crews/{crewId}")
-    class DeleteCrew {
-        final String BASE_URL = "/api/crews/{crewId}";
+	@Nested
+	@DisplayName("DELETE /api/crews/{crewId}")
+	class DeleteCrew {
+		final String BASE_URL = "/api/crews/{crewId}";
 
-        @Test
-        @DisplayName("크루를 삭제한다.")
-        void deleteCrew() {
-            long userId = 1L;
-            CrewMemberCount count1 = CrewMemberCount.of(1L);
-            count1.increment();
-            CrewMemberCount count2 = CrewMemberCount.of(2L);
-            count2.increment();
-            crewRepository.save(count1);
-            crewRepository.save(count2);
-            Crew crew = Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123"));
-            crew.joinMember(2L);
-            Crew savedCrew = crewRepository.save(crew);
+		@Test
+		@DisplayName("크루를 삭제한다.")
+		void deleteCrew() {
+			long userId = 1L;
+			CrewMemberCount count1 = CrewMemberCount.of(1L);
+			count1.increment();
+			CrewMemberCount count2 = CrewMemberCount.of(2L);
+			count2.increment();
+			crewRepository.save(count1);
+			crewRepository.save(count2);
+			Crew crew = Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123"));
+			crew.joinMember(2L);
+			Crew savedCrew = crewRepository.save(crew);
 
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("X-USER-ID", String.valueOf(userId));
-            ParameterizedTypeReference<ApiResponse<CrewResponse.Disband>> responseType = new ParameterizedTypeReference<>() {
-            };
+			HttpHeaders httpHeaders = new HttpHeaders();
+			httpHeaders.add("X-USER-ID", String.valueOf(userId));
+			ParameterizedTypeReference<ApiResponse<CrewResponse.Disband>> responseType = new ParameterizedTypeReference<>() {
+			};
 
-            ResponseEntity<ApiResponse<CrewResponse.Disband>> response =
-                    testRestTemplate.exchange(BASE_URL, HttpMethod.DELETE, new HttpEntity<>(httpHeaders), responseType,
-                            savedCrew.getId());
+			ResponseEntity<ApiResponse<CrewResponse.Disband>> response =
+				testRestTemplate.exchange(BASE_URL, HttpMethod.DELETE, new HttpEntity<>(httpHeaders), responseType,
+					savedCrew.getId());
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getResult().name()).isEqualTo(savedCrew.getName());
-        }
-    }
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getBody().getResult().name()).isEqualTo(savedCrew.getName());
+		}
+	}
 
-    @Nested
-    @DisplayName("PATCH /api/crews/{crewId}/leader")
-    class UpdateLeader {
-        final String BASE_URL = "/api/crews/{crewId}/leader";
+	@Nested
+	@DisplayName("PATCH /api/crews/{crewId}/leader")
+	class UpdateLeader {
+		final String BASE_URL = "/api/crews/{crewId}/leader";
 
-        @Test
-        @DisplayName("크루의 리더를 변경한다.")
-        void updateLeader() {
-            long userId = 1L;
-            Crew crew = Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123"));
-            crew.joinMember(2L);
-            Crew savedCrew = crewRepository.save(crew);
+		@Test
+		@DisplayName("크루의 리더를 변경한다.")
+		void updateLeader() {
+			long userId = 1L;
+			Crew crew = Crew.of(new CrewCommand.Create(userId, "Crew"), new Code("abc123"));
+			crew.joinMember(2L);
+			Crew savedCrew = crewRepository.save(crew);
 
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("X-USER-ID", String.valueOf(userId));
-            ParameterizedTypeReference<ApiResponse<CrewResponse.Delegate>> responseType = new ParameterizedTypeReference<>() {
-            };
+			HttpHeaders httpHeaders = new HttpHeaders();
+			httpHeaders.add("X-USER-ID", String.valueOf(userId));
+			ParameterizedTypeReference<ApiResponse<CrewResponse.Delegate>> responseType = new ParameterizedTypeReference<>() {
+			};
 
-            CrewRequest.Delegate request = new CrewRequest.Delegate(2L);
-            ResponseEntity<ApiResponse<CrewResponse.Delegate>> response =
-                    testRestTemplate.exchange(BASE_URL, HttpMethod.PATCH, new HttpEntity<>(request, httpHeaders),
-                            responseType, savedCrew.getId());
+			CrewRequest.Delegate request = new CrewRequest.Delegate(2L);
+			ResponseEntity<ApiResponse<CrewResponse.Delegate>> response =
+				testRestTemplate.exchange(BASE_URL, HttpMethod.PATCH, new HttpEntity<>(request, httpHeaders),
+					responseType, savedCrew.getId());
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getResult().leaderId()).isEqualTo(2L);
-        }
-    }
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getBody().getResult().leaderId()).isEqualTo(2L);
+		}
+	}
 
-    @Nested
-    @DisplayName("DELETE /api/crews/{crewId}/members/{memberId}")
-    class BanMember {
-        final String BASE_URL = "/api/crews/{crewId}/members/{memberId}";
+	@Nested
+	@DisplayName("DELETE /api/crews/{crewId}/members/{memberId}")
+	class BanMember {
+		final String BASE_URL = "/api/crews/{crewId}/members/{memberId}";
 
-        @Test
-        @DisplayName("크루에서 멤버를 추방한다.")
-        void banMember() {
-            long userId = 1L;
-            CrewMemberCount count1 = CrewMemberCount.of(1L);
-            count1.increment();
-            CrewMemberCount count2 = CrewMemberCount.of(2L);
-            count2.increment();
-            crewRepository.save(count1);
-            crewRepository.save(count2);
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Crew"), new Code("abc123"));
-            crew.joinMember(2L);
-            Crew savedCrew = crewRepository.save(crew);
+		@Test
+		@DisplayName("크루에서 멤버를 추방한다.")
+		void banMember() {
+			long userId = 1L;
+			CrewMemberCount count1 = CrewMemberCount.of(1L);
+			count1.increment();
+			CrewMemberCount count2 = CrewMemberCount.of(2L);
+			count2.increment();
+			crewRepository.save(count1);
+			crewRepository.save(count2);
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Crew"), new Code("abc123"));
+			crew.joinMember(2L);
+			Crew savedCrew = crewRepository.save(crew);
 
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.add("X-USER-ID", String.valueOf(1L));
-            ParameterizedTypeReference<ApiResponse<CrewResponse.Ban>> responseType = new ParameterizedTypeReference<>() {
-            };
+			HttpHeaders httpHeaders = new HttpHeaders();
+			httpHeaders.add("X-USER-ID", String.valueOf(1L));
+			ParameterizedTypeReference<ApiResponse<CrewResponse.Ban>> responseType = new ParameterizedTypeReference<>() {
+			};
 
-            ResponseEntity<ApiResponse<CrewResponse.Ban>> response =
-                    testRestTemplate.exchange(BASE_URL, HttpMethod.DELETE, new HttpEntity<>(httpHeaders), responseType,
-                            savedCrew.getId(), 2L);
+			ResponseEntity<ApiResponse<CrewResponse.Ban>> response =
+				testRestTemplate.exchange(BASE_URL, HttpMethod.DELETE, new HttpEntity<>(httpHeaders), responseType,
+					savedCrew.getId(), 2L);
 
-            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getResult().targetId()).isEqualTo(2L);
-        }
-    }
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+			assertThat(response.getBody().getResult().targetId()).isEqualTo(2L);
+		}
+	}
 }

--- a/src/test/java/com/runky/crew/domain/CrewServiceTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewServiceTest.java
@@ -20,206 +20,206 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CrewServiceTest {
 
-    @InjectMocks
-    private CrewService crewService;
-    @Mock
-    private CrewRepository crewRepository;
-    @Mock
-    private CodeGenerator codeGenerator;
+	@InjectMocks
+	private CrewService crewService;
+	@Mock
+	private CrewRepository crewRepository;
+	@Mock
+	private CodeGenerator codeGenerator;
 
-    @DisplayName("크루 생성 시,")
-    @Nested
-    class Create {
+	@DisplayName("크루 생성 시,")
+	@Nested
+	class Create {
 
-        @Test
-        @DisplayName("사용자의 크루 가입 수 정보가 없는 경우, NOT_FOUND 예외를 발생시킨다.")
-        void throwNotFoundException_whenMemberCrewCountNotFound() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "Test Crew");
-            given(crewRepository.findCountByMemberId(command.userId()))
-                    .willReturn(Optional.empty());
+		@Test
+		@DisplayName("사용자의 크루 가입 수 정보가 없는 경우, NOT_FOUND 예외를 발생시킨다.")
+		void throwNotFoundException_whenMemberCrewCountNotFound() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "Test Crew");
+			given(crewRepository.findCountByMemberId(command.userId()))
+				.willReturn(Optional.empty());
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.create(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.create(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
-        }
-    }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
+		}
+	}
 
-    @DisplayName("크루 가입 시,")
-    @Nested
-    class Join {
+	@DisplayName("크루 가입 시,")
+	@Nested
+	class Join {
 
-        @Test
-        @DisplayName("탈퇴했던 크루일 경우, 재가입 처리된다.")
-        void rejoinCrew_whenAlreadyJoined() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Crew"), new Code("ABC123"));
-            crew.joinMember(2L);
-            crew.leaveMember(2L);
-            given(crewRepository.findCrewByCode(crew.getCode()))
-                    .willReturn(Optional.of(crew));
-            given(crewRepository.findCountByMemberId(2L))
-                    .willReturn(Optional.of(CrewMemberCount.of(2L)));
-            CrewCommand.Join command = new CrewCommand.Join(2L, crew.getCode().value());
+		@Test
+		@DisplayName("탈퇴했던 크루일 경우, 재가입 처리된다.")
+		void rejoinCrew_whenAlreadyJoined() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Crew"), new Code("ABC123"));
+			crew.joinMember(2L);
+			crew.leaveMember(2L);
+			given(crewRepository.findCrewByCode(crew.getCode()))
+				.willReturn(Optional.of(crew));
+			given(crewRepository.findCountByMemberId(2L))
+				.willReturn(Optional.of(CrewMemberCount.of(2L)));
+			CrewCommand.Join command = new CrewCommand.Join(2L, crew.getCode().value());
 
-            Crew joinedCrew = crewService.join(command);
+			Crew joinedCrew = crewService.join(command);
 
-            assertThat(joinedCrew.getMember(2L).getRole()).isEqualTo(CrewMember.Role.MEMBER);
-            assertThat(joinedCrew.getMember(2L).isInCrew()).isTrue();
-        }
+			assertThat(joinedCrew.getMember(2L).getRole()).isEqualTo(CrewMember.Role.MEMBER);
+			assertThat(joinedCrew.getMember(2L).isInCrew()).isTrue();
+		}
 
-        @Test
-        @DisplayName("크루에 처음 가입하는 경우, 새로운 멤버로 추가된다.")
-        void joinCrew_whenFirstTimeJoining() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "New Crew"), new Code("XYZ789"));
-            given(crewRepository.findCrewByCode(crew.getCode()))
-                    .willReturn(Optional.of(crew));
-            given(crewRepository.findCountByMemberId(3L))
-                    .willReturn(Optional.of(CrewMemberCount.of(3L)));
-            CrewCommand.Join command = new CrewCommand.Join(3L, crew.getCode().value());
+		@Test
+		@DisplayName("크루에 처음 가입하는 경우, 새로운 멤버로 추가된다.")
+		void joinCrew_whenFirstTimeJoining() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "New Crew"), new Code("XYZ789"));
+			given(crewRepository.findCrewByCode(crew.getCode()))
+				.willReturn(Optional.of(crew));
+			given(crewRepository.findCountByMemberId(3L))
+				.willReturn(Optional.of(CrewMemberCount.of(3L)));
+			CrewCommand.Join command = new CrewCommand.Join(3L, crew.getCode().value());
 
-            Crew joinedCrew = crewService.join(command);
+			Crew joinedCrew = crewService.join(command);
 
-            assertThat(joinedCrew.getMember(3L).getRole()).isEqualTo(CrewMember.Role.MEMBER);
-            assertThat(joinedCrew.getMember(3L).isInCrew()).isTrue();
-        }
-    }
+			assertThat(joinedCrew.getMember(3L).getRole()).isEqualTo(CrewMember.Role.MEMBER);
+			assertThat(joinedCrew.getMember(3L).isInCrew()).isTrue();
+		}
+	}
 
-    @Nested
-    @DisplayName("크루 상세 조회 시,")
-    class Detail {
-        @Test
-        @DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
-        void throwNotFoundCrewException_whenCrewNotFound() {
-            CrewCommand.Detail command = new CrewCommand.Detail(1L, 2L);
-            given(crewRepository.findById(command.crewId()))
-                    .willReturn(Optional.empty());
+	@Nested
+	@DisplayName("크루 상세 조회 시,")
+	class Detail {
+		@Test
+		@DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
+		void throwNotFoundCrewException_whenCrewNotFound() {
+			CrewCommand.Detail command = new CrewCommand.Detail(1L, 2L);
+			given(crewRepository.findById(command.crewId()))
+				.willReturn(Optional.empty());
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrew(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrew(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
-        }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
+		}
 
-        @Test
-        @DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
-        void throwNotCrewMemberException_whenUserNotInCrew() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("abc123"));
-            given(crewRepository.findById(crew.getId()))
-                    .willReturn(Optional.of(crew));
-            CrewCommand.Detail command = new CrewCommand.Detail(crew.getId(), 3L);
+		@Test
+		@DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
+		void throwNotCrewMemberException_whenUserNotInCrew() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("abc123"));
+			given(crewRepository.findById(crew.getId()))
+				.willReturn(Optional.of(crew));
+			CrewCommand.Detail command = new CrewCommand.Detail(crew.getId(), 3L);
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrew(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrew(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
-    }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
+	}
 
-    @Nested
-    @DisplayName("크루원 목록 조회 시,")
-    class GetMembers {
+	@Nested
+	@DisplayName("크루원 목록 조회 시,")
+	class GetMembers {
 
-        @Test
-        @DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
-        void throwNotFoundCrewException_whenCrewNotFound() {
-            CrewCommand.Members command = new CrewCommand.Members(1L, 2L);
-            given(crewRepository.findById(command.crewId()))
-                    .willReturn(Optional.empty());
+		@Test
+		@DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
+		void throwNotFoundCrewException_whenCrewNotFound() {
+			CrewCommand.Members command = new CrewCommand.Members(1L, 2L);
+			given(crewRepository.findById(command.crewId()))
+				.willReturn(Optional.empty());
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrewMembers(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrewMembers(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
-        }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
+		}
 
-        @Test
-        @DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
-        void throwNotCrewMemberException_whenUserNotInCrew() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("xyz789"));
-            given(crewRepository.findById(crew.getId()))
-                    .willReturn(Optional.of(crew));
-            CrewCommand.Members command = new CrewCommand.Members(crew.getId(), 3L);
+		@Test
+		@DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
+		void throwNotCrewMemberException_whenUserNotInCrew() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("xyz789"));
+			given(crewRepository.findById(crew.getId()))
+				.willReturn(Optional.of(crew));
+			CrewCommand.Members command = new CrewCommand.Members(crew.getId(), 3L);
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrewMembers(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrewMembers(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
 
-        @Test
-        @DisplayName("현재 크루에 활동중인 멤버만 조회된다.")
-        void getActiveMembers() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Active Crew"), new Code("abc123"));
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-            crew.leaveMember(3L);
-            given(crewRepository.findById(crew.getId()))
-                    .willReturn(Optional.of(crew));
-            CrewCommand.Members command = new CrewCommand.Members(crew.getId(), 1L);
+		@Test
+		@DisplayName("현재 크루에 활동중인 멤버만 조회된다.")
+		void getActiveMembers() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Active Crew"), new Code("abc123"));
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+			crew.leaveMember(3L);
+			given(crewRepository.findById(crew.getId()))
+				.willReturn(Optional.of(crew));
+			CrewCommand.Members command = new CrewCommand.Members(crew.getId(), 1L);
 
-            List<CrewMember> members = crewService.getCrewMembers(command);
+			List<CrewMember> members = crewService.getCrewMembers(command);
 
-            assertThat(members).hasSize(2);
-            assertThat(members)
-                    .extracting("memberId")
-                    .containsExactlyInAnyOrder(1L, 2L);
-        }
-    }
+			assertThat(members).hasSize(2);
+			assertThat(members)
+				.extracting("memberId")
+				.containsExactlyInAnyOrder(1L, 2L);
+		}
+	}
 
-    @Nested
-    @DisplayName("크루원 탈퇴 시,")
-    class Leave {
+	@Nested
+	@DisplayName("크루원 탈퇴 시,")
+	class Leave {
 
-        @Test
-        @DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
-        void throwNotFoundCrewException_whenCrewNotFound() {
-            CrewCommand.Leave command = new CrewCommand.Leave(1L, 2L, null);
-            given(crewRepository.findById(command.crewId()))
-                    .willReturn(Optional.empty());
+		@Test
+		@DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
+		void throwNotFoundCrewException_whenCrewNotFound() {
+			CrewCommand.Leave command = new CrewCommand.Leave(1L, 2L, null);
+			given(crewRepository.findById(command.crewId()))
+				.willReturn(Optional.empty());
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
-        }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
+		}
 
-        @Test
-        @DisplayName("리더가 탈퇴할 경우 새로운 리더를 지정하지 않으면, HAVE_TO_DELEGATE_LEADER 예외를 발생시킨다.")
-        void throwHaveToDelegateLeaderException_whenLeaderLeavesWithoutDelegation() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("def456"));
-            crew.joinMember(2L);
-            given(crewRepository.findById(crew.getId()))
-                    .willReturn(Optional.of(crew));
-            CrewCommand.Leave command = new CrewCommand.Leave(crew.getId(), 1L, null);
+		@Test
+		@DisplayName("리더가 탈퇴할 경우 새로운 리더를 지정하지 않으면, HAVE_TO_DELEGATE_LEADER 예외를 발생시킨다.")
+		void throwHaveToDelegateLeaderException_whenLeaderLeavesWithoutDelegation() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("def456"));
+			crew.joinMember(2L);
+			given(crewRepository.findById(crew.getId()))
+				.willReturn(Optional.of(crew));
+			CrewCommand.Leave command = new CrewCommand.Leave(crew.getId(), 1L, null);
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.HAVE_TO_DELEGATE_LEADER));
-        }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.HAVE_TO_DELEGATE_LEADER));
+		}
 
-        @Test
-        @DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
-        void throwNotCrewMemberException_whenUserNotInCrew() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("xyz789"));
-            crew.joinMember(3L);
-            crew.leaveMember(3L);
-            given(crewRepository.findById(crew.getId()))
-                    .willReturn(Optional.of(crew));
-            CrewCommand.Leave command = new CrewCommand.Leave(crew.getId(), 3L, null);
+		@Test
+		@DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
+		void throwNotCrewMemberException_whenUserNotInCrew() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("xyz789"));
+			crew.joinMember(3L);
+			crew.leaveMember(3L);
+			given(crewRepository.findById(crew.getId()))
+				.willReturn(Optional.of(crew));
+			CrewCommand.Leave command = new CrewCommand.Leave(crew.getId(), 3L, null);
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
-    }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
+	}
 }

--- a/src/test/java/com/runky/crew/domain/CrewTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewTest.java
@@ -16,584 +16,584 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 class CrewTest {
 
-    @Nested
-    @DisplayName("크루 생성 시,")
-    class Create {
-
-        @Test
-        @DisplayName("크루 이름이 공백이면, BLANK_CREW_NAME 예외가 발생한다.")
-        void throwBlankCrewNameException_whenNameIsBlank() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "  ");
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> Crew.of(command, new Code("ABC123")));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.BLANK_CREW_NAME));
-        }
-
-        @Test
-        @DisplayName("크루 이름이 10자를 초과하면, OVER_CREW_NAME 예외가 발생한다.")
-        void throwOverCrewNameException_whenNameIsOver10() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ThisNameIsTooLong");
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> Crew.of(command, new Code("ABC123")));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_NAME));
-        }
-
-        @Test
-        @DisplayName("공지는 공백으로 생성된다.")
-        void returnBlankNotice_whenCreated() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-
-            Crew crew = Crew.of(command, code);
-
-            assertThat(crew.getNotice()).isEqualTo("");
-        }
-
-        @Test
-        @DisplayName("크루 현 인원은 생성한 사람을 포함한 1명으로 생성된다.")
-        void returnZeroMemberCount_whenCreated() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-
-            Crew crew = Crew.of(command, code);
-
-            assertThat(crew.getActiveMemberCount()).isEqualTo(1L);
-        }
-
-        @Test
-        @DisplayName("크루를 생성한 사람은 리더로 존재한다.")
-        void createLeader() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-
-            Crew crew = Crew.of(command, code);
-
-            assertThat(crew.getMembers()).hasSize(1);
-            assertThat(crew.getMembers().get(0).getRole()).isEqualTo(CrewMember.Role.LEADER);
-        }
-    }
-
-    @Test
-    @DisplayName("크루원 추가 시, 인원 수가 초과하면, OVER_CREW_MEMBER_COUNT 예외가 발생한다.")
-    void throwOverCrewMemberCountException_whenAddingMemberExceedsCapacity() {
-        CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-        Code code = new Code("ABC123");
-        Crew crew = Crew.of(command, code);
-        crew.joinMember(2L);
-        crew.joinMember(3L);
-        crew.joinMember(4L);
-        crew.joinMember(5L);
-        crew.joinMember(6L);
-
-        GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(7L));
-
-        assertThat(thrown)
-                .usingRecursiveComparison()
-                .isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_MEMBER_COUNT));
-    }
-
-    @Nested
-    @DisplayName("크루 가입 시,")
-    class Join {
-
-        @Test
-        @DisplayName("가입한 기록이 있는 경우, 추방된 멤버라면, BANNED_MEMBER 예외가 발생한다.")
-        void throwBannedMemberException_whenJoiningBannedMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.banMember(2L);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.BANNED_MEMBER));
-        }
-
-        @Test
-        @DisplayName("가입한 기록이 있는 경우, 이미 가입된 멤버라면, ALREADY_IN_CREW 예외가 발생한다.")
-        void throwAlreadyInCrewException_whenJoiningAlreadyJoinedMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.ALREADY_IN_CREW));
-        }
-
-        @Test
-        @DisplayName("이미 가입한 크루일 경우, ALREADY_IN_CREW 예외가 발생한다.")
-        void throwAlreadyInCrewException_whenJoiningAlreadyJoinedCrew() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.ALREADY_IN_CREW));
-        }
-
-        @Test
-        @DisplayName("크루가 이미 꽉 찬 경우, OVER_CREW_MEMBER_COUNT 예외가 발생한다.")
-        void throwOverCrewMemberCountException_whenJoiningFullCrew() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-            crew.joinMember(4L);
-            crew.joinMember(5L);
-            crew.joinMember(6L);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(7L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_MEMBER_COUNT));
-        }
-    }
-
-    @Nested
-    @DisplayName("크루원 추방 시,")
-    class Ban {
-
-        @Test
-        @DisplayName("탈퇴한 크루원을 추방하려고 하면, NOT_CREW_MEMBER 예외가 발생한다.")
-        void throwNotInCrewException_whenBanningLeftMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.leaveMember(2L);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.banMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
-
-        @Test
-        @DisplayName("크루원이 존재하지 않으면, NOT_CREW_MEMBER 예외가 발생한다.")
-        void throwNotFoundException_whenBanningNonExistentMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.banMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
-
-        @Test
-        @DisplayName("크루원 추방 후, 크루원 수가 감소한다.")
-        void decrementActiveMemberCount_whenBanningMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-
-            crew.banMember(2L);
-
-            assertThat(crew.getActiveMemberCount()).isEqualTo(2L);
-        }
-    }
-
-    @Nested
-    @DisplayName("크루원 탈퇴 시,")
-    class Leave {
-
-        @Test
-        @DisplayName("이미 크루에 존재하지 않으면, NOT_CREW_MEMBER 예외가 발생한다.")
-        void throwNotCrewMemberException_whenLeavingNonExistentMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.leaveMember(2L);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.leaveMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
-
-        @Test
-        @DisplayName("크루원이 존재하지 않으면, NOT_CREW_MEMBER 예외가 발생한다.")
-        void throwNotFoundException_whenLeavingNonExistentMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.leaveMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
-
-        @Test
-        @DisplayName("크루원 탈퇴 후, 크루원 수가 감소한다.")
-        void decrementActiveMemberCount_whenLeavingMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-
-            crew.leaveMember(2L);
-
-            assertThat(crew.getActiveMemberCount()).isEqualTo(2L);
-        }
-    }
-
-    @Nested
-    @DisplayName("크루 리더 위임 시,")
-    class Delegate {
-
-        @Test
-        @DisplayName("새 리더를 지정하지 않으면, HAVE_TO_DELEGATE_LEADER 예외가 발생한다.")
-        void throwHaveToDelegateLeaderException_whenNoNewLeaderSpecified() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.delegateLeader(null));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.HAVE_TO_DELEGATE_LEADER));
-        }
-
-        @Test
-        @DisplayName("새 리더는 LEADER 역할로 지정되고, Crew의 LeaderId가 변경된다.")
-        void delegateLeader() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-
-            crew.delegateLeader(2L);
-
-            assertThat(crew.getLeader().getMemberId()).isEqualTo(2L);
-            assertThat(crew.getLeader().getRole()).isEqualTo(CrewMember.Role.LEADER);
-            assertThat(crew.getLeaderId()).isEqualTo(2L);
-        }
-
-        @Test
-        @DisplayName("이전 리더는 MEMBER 역할로 변경된다.")
-        void previousLeaderBecomesMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-
-            crew.delegateLeader(2L);
-
-            CrewMember previousLeader = crew.getMember(1L);
-            assertThat(previousLeader.getRole()).isEqualTo(CrewMember.Role.MEMBER);
-        }
-    }
-
-    @Nested
-    @DisplayName("크루 유저 수 감소 시,")
-    class Decrement {
-
-        @Test
-        @DisplayName("마지막 남은 유저는 탈퇴할 수 없다.")
-        void throwCannotLeaveLastMemberException_whenDecrementingLastMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, crew::decrementActiveMemberCount);
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.LAST_CREW_MEMBER));
-        }
-    }
-
-    @Test
-    @DisplayName("크루의 리더를 조회한다.")
-    void getLeader() {
-        CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-        Code code = new Code("ABC123");
-        Crew crew = Crew.of(command, code);
-        crew.joinMember(2L);
-        crew.joinMember(3L);
-        crew.joinMember(4L);
-
-        CrewMember leader = crew.getLeader();
-
-        assertThat(leader.getRole()).isEqualTo(CrewMember.Role.LEADER);
-        assertThat(leader.getMemberId()).isEqualTo(1L);
-    }
-
-    @Nested
-    @DisplayName("크루 해체 시,")
-    class Disband {
-
-        @Test
-        @DisplayName("모든 멤버의 상태는 LEFT로 변경된다.")
-        void changeAllMembersToLeft() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-
-            crew.disband();
-
-            List<CrewMember> members = crew.getMembers();
-            assertThat(members).allMatch(member -> member.getRole() == CrewMember.Role.LEFT);
-        }
-
-        @Test
-        @DisplayName("크루의 활동 멤버 수는 0이 된다.")
-        void setActiveMemberCountToZero() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-
-            crew.disband();
-
-            assertThat(crew.getActiveMemberCount()).isEqualTo(0L);
-        }
-
-        @Test
-        @DisplayName("deletedAt이 기록된다.")
-        void recordDeletedAt() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-            ZonedDateTime before = crew.getDeletedAt();
-
-            crew.disband();
-
-            ZonedDateTime after = crew.getDeletedAt();
-            assertThat(before).isNull();
-            assertThat(after).isNotNull();
-        }
-
-        @Test
-        @DisplayName("해체 당시 크루 멤버들을 반환한다.")
-        void returnMembersOnDisband() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-            crew.banMember(3L);
-            crew.joinMember(4L);
-            crew.leaveMember(4L);
-            List<CrewMember> activeMembers = crew.getActiveMembers();
-
-            List<CrewMember> disbandedMembers = crew.disband();
-
-            assertThat(disbandedMembers).hasSize(2);
-            assertThat(disbandedMembers).extracting("memberId")
-                    .containsExactlyInAnyOrder(1L, 2L);
-        }
-    }
-
-    @Nested
-    @DisplayName("크루 공지 변경 시,")
-    class UpdateNotice {
-
-        @Test
-        @DisplayName("변경 내용이 존재하지 않다면, INVALID_NOTICE 예외가 발생한다.")
-        void throwInvalidNoticeException_whenNoticeIsNull() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.updateNotice(null));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.INVALID_NOTICE));
-        }
-
-        @Test
-        @DisplayName("변경 내용이 20자를 초과하면, INVALID_NOTICE 예외가 발생한다.")
-        void throwInvalidNoticeException_whenNoticeIsOver20Characters() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.updateNotice("This notice is way too long for the limit."));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.INVALID_NOTICE));
-        }
-    }
-
-    @Nested
-    @DisplayName("크루 이름 변경 시,")
-    class UpdateName {
-
-        @ParameterizedTest(name = "{index} - {0}")
-        @NullAndEmptySource
-        @DisplayName("변경 내용이 공백이면, BLANK_CREW_NAME 예외가 발생한다.")
-        void throwBlankCrewNameException_whenNameIsBlank(String name) {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.updateName(name));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.BLANK_CREW_NAME));
-        }
-
-        @Test
-        @DisplayName("변경 이름이 15자를 초과하면, OVER_CREW_NAME 예외가 발생한다.")
-        void throwOverCrewNameException_whenNameIsOver15Characters() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.updateName("ThisNameIsWayTooLong"));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_NAME));
-        }
-    }
-
-    @Nested
-    @DisplayName("크루 내 가입했던 멤버 조회 시,")
-    class GetHistory {
-
-        @Test
-        @DisplayName("가입한 적이 없다면, NOT_FOUND 예외가 발생한다.")
-        void throwNotFoundException_whenGettingNonExistentMemberHistory() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMemberHistory(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
-        }
-    }
-
-    @Nested
-    @DisplayName("크루 내 활동중인 멤버 조회 시,")
-    class GetMember {
-
-        @Test
-        @DisplayName("크루 내 활동중인 멤버 조회 시, 멤버가 존재하지 않다면, NOT_CREW_MEMBER 예외가 발생한다.")
-        void throwNotFoundException_whenGettingNonExistentMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
-
-        @Test
-        @DisplayName("크루 내 활동중인 멤버 조회 시, 탈퇴한 멤버라면, NOT_CREW_MEMBER 예외가 발생한다.")
-        void throwNotFoundException_whenGettingLeftMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.leaveMember(2L);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
-
-        @Test
-        @DisplayName("크루 내 활동중인 멤버 조회 시, 추방 멤버라면, NOT_CREW_MEMBER 예외가 발생한다.")
-        void throwNotFoundException_whenGettingBannedMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.banMember(2L);
-
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMember(2L));
-
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
-
-        @Test
-        @DisplayName("크루의 멤버를 조회한다.")
-        void getMember() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-
-            CrewMember member = crew.getMember(2L);
-
-            assertThat(member.getMemberId()).isEqualTo(2L);
-            assertThat(member.getRole()).isEqualTo(CrewMember.Role.MEMBER);
-        }
-    }
-
-    @Nested
-    @DisplayName("크루의 활동 멤버 조회 시,")
-    class GetActiveMembers {
-
-        @Test
-        @DisplayName("크루의 활동 멤버를 조회한다.")
-        void getActiveMembers() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
-            Code code = new Code("ABC123");
-            Crew crew = Crew.of(command, code);
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-            crew.joinMember(4L);
-            crew.leaveMember(4L);
-
-            List<CrewMember> activeMembers = crew.getActiveMembers();
-
-            assertThat(activeMembers).hasSize(3);
-            assertThat(activeMembers).extracting("memberId")
-                    .containsExactlyInAnyOrder(1L, 2L, 3L);
-        }
-    }
+	@Nested
+	@DisplayName("크루 생성 시,")
+	class Create {
+
+		@Test
+		@DisplayName("크루 이름이 공백이면, BLANK_CREW_NAME 예외가 발생한다.")
+		void throwBlankCrewNameException_whenNameIsBlank() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "  ");
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> Crew.of(command, new Code("ABC123")));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.BLANK_CREW_NAME));
+		}
+
+		@Test
+		@DisplayName("크루 이름이 10자를 초과하면, OVER_CREW_NAME 예외가 발생한다.")
+		void throwOverCrewNameException_whenNameIsOver10() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ThisNameIsTooLong");
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> Crew.of(command, new Code("ABC123")));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_NAME));
+		}
+
+		@Test
+		@DisplayName("공지는 공백으로 생성된다.")
+		void returnBlankNotice_whenCreated() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+
+			Crew crew = Crew.of(command, code);
+
+			assertThat(crew.getNotice()).isEqualTo("");
+		}
+
+		@Test
+		@DisplayName("크루 현 인원은 생성한 사람을 포함한 1명으로 생성된다.")
+		void returnZeroMemberCount_whenCreated() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+
+			Crew crew = Crew.of(command, code);
+
+			assertThat(crew.getActiveMemberCount()).isEqualTo(1L);
+		}
+
+		@Test
+		@DisplayName("크루를 생성한 사람은 리더로 존재한다.")
+		void createLeader() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+
+			Crew crew = Crew.of(command, code);
+
+			assertThat(crew.getMembers()).hasSize(1);
+			assertThat(crew.getMembers().get(0).getRole()).isEqualTo(CrewMember.Role.LEADER);
+		}
+	}
+
+	@Test
+	@DisplayName("크루원 추가 시, 인원 수가 초과하면, OVER_CREW_MEMBER_COUNT 예외가 발생한다.")
+	void throwOverCrewMemberCountException_whenAddingMemberExceedsCapacity() {
+		CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+		Code code = new Code("ABC123");
+		Crew crew = Crew.of(command, code);
+		crew.joinMember(2L);
+		crew.joinMember(3L);
+		crew.joinMember(4L);
+		crew.joinMember(5L);
+		crew.joinMember(6L);
+
+		GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(7L));
+
+		assertThat(thrown)
+			.usingRecursiveComparison()
+			.isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_MEMBER_COUNT));
+	}
+
+	@Nested
+	@DisplayName("크루 가입 시,")
+	class Join {
+
+		@Test
+		@DisplayName("가입한 기록이 있는 경우, 추방된 멤버라면, BANNED_MEMBER 예외가 발생한다.")
+		void throwBannedMemberException_whenJoiningBannedMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.banMember(2L);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(2L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.BANNED_MEMBER));
+		}
+
+		@Test
+		@DisplayName("가입한 기록이 있는 경우, 이미 가입된 멤버라면, ALREADY_IN_CREW 예외가 발생한다.")
+		void throwAlreadyInCrewException_whenJoiningAlreadyJoinedMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(2L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.ALREADY_IN_CREW));
+		}
+
+		@Test
+		@DisplayName("이미 가입한 크루일 경우, ALREADY_IN_CREW 예외가 발생한다.")
+		void throwAlreadyInCrewException_whenJoiningAlreadyJoinedCrew() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(2L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.ALREADY_IN_CREW));
+		}
+
+		@Test
+		@DisplayName("크루가 이미 꽉 찬 경우, OVER_CREW_MEMBER_COUNT 예외가 발생한다.")
+		void throwOverCrewMemberCountException_whenJoiningFullCrew() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+			crew.joinMember(4L);
+			crew.joinMember(5L);
+			crew.joinMember(6L);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.joinMember(7L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_MEMBER_COUNT));
+		}
+	}
+
+	@Nested
+	@DisplayName("크루원 추방 시,")
+	class Ban {
+
+		@Test
+		@DisplayName("탈퇴한 크루원을 추방하려고 하면, NOT_CREW_MEMBER 예외가 발생한다.")
+		void throwNotInCrewException_whenBanningLeftMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.leaveMember(2L);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.banMember(2L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
+
+		@Test
+		@DisplayName("크루원이 존재하지 않으면, NOT_CREW_MEMBER 예외가 발생한다.")
+		void throwNotFoundException_whenBanningNonExistentMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.banMember(2L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
+
+		@Test
+		@DisplayName("크루원 추방 후, 크루원 수가 감소한다.")
+		void decrementActiveMemberCount_whenBanningMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+
+			crew.banMember(2L);
+
+			assertThat(crew.getActiveMemberCount()).isEqualTo(2L);
+		}
+	}
+
+	@Nested
+	@DisplayName("크루원 탈퇴 시,")
+	class Leave {
+
+		@Test
+		@DisplayName("이미 크루에 존재하지 않으면, NOT_CREW_MEMBER 예외가 발생한다.")
+		void throwNotCrewMemberException_whenLeavingNonExistentMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.leaveMember(2L);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.leaveMember(2L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
+
+		@Test
+		@DisplayName("크루원이 존재하지 않으면, NOT_CREW_MEMBER 예외가 발생한다.")
+		void throwNotFoundException_whenLeavingNonExistentMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.leaveMember(2L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
+
+		@Test
+		@DisplayName("크루원 탈퇴 후, 크루원 수가 감소한다.")
+		void decrementActiveMemberCount_whenLeavingMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+
+			crew.leaveMember(2L);
+
+			assertThat(crew.getActiveMemberCount()).isEqualTo(2L);
+		}
+	}
+
+	@Nested
+	@DisplayName("크루 리더 위임 시,")
+	class Delegate {
+
+		@Test
+		@DisplayName("새 리더를 지정하지 않으면, HAVE_TO_DELEGATE_LEADER 예외가 발생한다.")
+		void throwHaveToDelegateLeaderException_whenNoNewLeaderSpecified() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.delegateLeader(null));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.HAVE_TO_DELEGATE_LEADER));
+		}
+
+		@Test
+		@DisplayName("새 리더는 LEADER 역할로 지정되고, Crew의 LeaderId가 변경된다.")
+		void delegateLeader() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+
+			crew.delegateLeader(2L);
+
+			assertThat(crew.getLeader().getMemberId()).isEqualTo(2L);
+			assertThat(crew.getLeader().getRole()).isEqualTo(CrewMember.Role.LEADER);
+			assertThat(crew.getLeaderId()).isEqualTo(2L);
+		}
+
+		@Test
+		@DisplayName("이전 리더는 MEMBER 역할로 변경된다.")
+		void previousLeaderBecomesMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+
+			crew.delegateLeader(2L);
+
+			CrewMember previousLeader = crew.getMember(1L);
+			assertThat(previousLeader.getRole()).isEqualTo(CrewMember.Role.MEMBER);
+		}
+	}
+
+	@Nested
+	@DisplayName("크루 유저 수 감소 시,")
+	class Decrement {
+
+		@Test
+		@DisplayName("마지막 남은 유저는 탈퇴할 수 없다.")
+		void throwCannotLeaveLastMemberException_whenDecrementingLastMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+
+			GlobalException thrown = assertThrows(GlobalException.class, crew::decrementActiveMemberCount);
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.LAST_CREW_MEMBER));
+		}
+	}
+
+	@Test
+	@DisplayName("크루의 리더를 조회한다.")
+	void getLeader() {
+		CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+		Code code = new Code("ABC123");
+		Crew crew = Crew.of(command, code);
+		crew.joinMember(2L);
+		crew.joinMember(3L);
+		crew.joinMember(4L);
+
+		CrewMember leader = crew.getLeader();
+
+		assertThat(leader.getRole()).isEqualTo(CrewMember.Role.LEADER);
+		assertThat(leader.getMemberId()).isEqualTo(1L);
+	}
+
+	@Nested
+	@DisplayName("크루 해체 시,")
+	class Disband {
+
+		@Test
+		@DisplayName("모든 멤버의 상태는 LEFT로 변경된다.")
+		void changeAllMembersToLeft() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+
+			crew.disband();
+
+			List<CrewMember> members = crew.getMembers();
+			assertThat(members).allMatch(member -> member.getRole() == CrewMember.Role.LEFT);
+		}
+
+		@Test
+		@DisplayName("크루의 활동 멤버 수는 0이 된다.")
+		void setActiveMemberCountToZero() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+
+			crew.disband();
+
+			assertThat(crew.getActiveMemberCount()).isEqualTo(0L);
+		}
+
+		@Test
+		@DisplayName("deletedAt이 기록된다.")
+		void recordDeletedAt() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+			ZonedDateTime before = crew.getDeletedAt();
+
+			crew.disband();
+
+			ZonedDateTime after = crew.getDeletedAt();
+			assertThat(before).isNull();
+			assertThat(after).isNotNull();
+		}
+
+		@Test
+		@DisplayName("해체 당시 크루 멤버들을 반환한다.")
+		void returnMembersOnDisband() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+			crew.banMember(3L);
+			crew.joinMember(4L);
+			crew.leaveMember(4L);
+			List<CrewMember> activeMembers = crew.getActiveMembers();
+
+			List<CrewMember> disbandedMembers = crew.disband();
+
+			assertThat(disbandedMembers).hasSize(2);
+			assertThat(disbandedMembers).extracting("memberId")
+				.containsExactlyInAnyOrder(1L, 2L);
+		}
+	}
+
+	@Nested
+	@DisplayName("크루 공지 변경 시,")
+	class UpdateNotice {
+
+		@Test
+		@DisplayName("변경 내용이 존재하지 않다면, INVALID_NOTICE 예외가 발생한다.")
+		void throwInvalidNoticeException_whenNoticeIsNull() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.updateNotice(null));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.INVALID_NOTICE));
+		}
+
+		@Test
+		@DisplayName("변경 내용이 20자를 초과하면, INVALID_NOTICE 예외가 발생한다.")
+		void throwInvalidNoticeException_whenNoticeIsOver20Characters() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.updateNotice("This notice is way too long for the limit."));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.INVALID_NOTICE));
+		}
+	}
+
+	@Nested
+	@DisplayName("크루 이름 변경 시,")
+	class UpdateName {
+
+		@ParameterizedTest(name = "{index} - {0}")
+		@NullAndEmptySource
+		@DisplayName("변경 내용이 공백이면, BLANK_CREW_NAME 예외가 발생한다.")
+		void throwBlankCrewNameException_whenNameIsBlank(String name) {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.updateName(name));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.BLANK_CREW_NAME));
+		}
+
+		@Test
+		@DisplayName("변경 이름이 15자를 초과하면, OVER_CREW_NAME 예외가 발생한다.")
+		void throwOverCrewNameException_whenNameIsOver15Characters() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.updateName("ThisNameIsWayTooLong"));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.OVER_CREW_NAME));
+		}
+	}
+
+	@Nested
+	@DisplayName("크루 내 가입했던 멤버 조회 시,")
+	class GetHistory {
+
+		@Test
+		@DisplayName("가입한 적이 없다면, NOT_FOUND 예외가 발생한다.")
+		void throwNotFoundException_whenGettingNonExistentMemberHistory() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMemberHistory(2L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
+		}
+	}
+
+	@Nested
+	@DisplayName("크루 내 활동중인 멤버 조회 시,")
+	class GetMember {
+
+		@Test
+		@DisplayName("크루 내 활동중인 멤버 조회 시, 멤버가 존재하지 않다면, NOT_CREW_MEMBER 예외가 발생한다.")
+		void throwNotFoundException_whenGettingNonExistentMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMember(2L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
+
+		@Test
+		@DisplayName("크루 내 활동중인 멤버 조회 시, 탈퇴한 멤버라면, NOT_CREW_MEMBER 예외가 발생한다.")
+		void throwNotFoundException_whenGettingLeftMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.leaveMember(2L);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMember(2L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
+
+		@Test
+		@DisplayName("크루 내 활동중인 멤버 조회 시, 추방 멤버라면, NOT_CREW_MEMBER 예외가 발생한다.")
+		void throwNotFoundException_whenGettingBannedMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.banMember(2L);
+
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crew.getMember(2L));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
+
+		@Test
+		@DisplayName("크루의 멤버를 조회한다.")
+		void getMember() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+
+			CrewMember member = crew.getMember(2L);
+
+			assertThat(member.getMemberId()).isEqualTo(2L);
+			assertThat(member.getRole()).isEqualTo(CrewMember.Role.MEMBER);
+		}
+	}
+
+	@Nested
+	@DisplayName("크루의 활동 멤버 조회 시,")
+	class GetActiveMembers {
+
+		@Test
+		@DisplayName("크루의 활동 멤버를 조회한다.")
+		void getActiveMembers() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "ValidName");
+			Code code = new Code("ABC123");
+			Crew crew = Crew.of(command, code);
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+			crew.joinMember(4L);
+			crew.leaveMember(4L);
+
+			List<CrewMember> activeMembers = crew.getActiveMembers();
+
+			assertThat(activeMembers).hasSize(3);
+			assertThat(activeMembers).extracting("memberId")
+				.containsExactlyInAnyOrder(1L, 2L, 3L);
+		}
+	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #30

## 📌 작업 내용 및 특이사항

### 🚀 HTTP API (RunningController)
-  `POST /api/runnings/start`
   -  런닝 세션을 시작하고, 클라이언트가 위치를 발행(publish)할 WebSocket 주소를 응답에 포함합니다.

- `POST /api/runnings/{runningId}/end`
  - 런닝을 종료하고, 전체 런닝 요약 및 트랙 데이터를 저장합니다.

### 🚀 WebSocket API (RunningLocationWsController)

- `/app/runnings/{runningId}/location` 으로 들어온 실시간 좌표 메시지를 수신합니다.

-  수신된 좌표는 `/topic/runnings/{runningId}` 토픽을 구독하는 모든 클라이언트에게 브로드캐스팅합니다.

## 📝 참고사항
- STOMP API에서 SimpMessagingTemplate 대신 @SendTo 어노테이션을 사용하여 코드를 간소화했습니다.
- 이번 PR에는 테스트 코드가 포함되어 있지 않습니다.
- 다음 작업으로 알림 기능을 추가할 예정입니다.

### 🏃‍♂️ 프론트엔드 런닝 플로우
러너 입장
1. POST /api/runnings/start 요청 시 브로드캐스팅 주소(publishDestination)를 응답으로 수신합니다.

2. WebSocket에 연결합니다.

3. 수신한 publishDestination으로 매초 좌표를 전송합니다.

4. 런닝 종료 시 POST /api/runnings/{id}/end를 호출합니다.

크루원 입장
1. FCM 알림을 통해 runningTopic을 획득합니다.

2. WebSocket에 연결합니다.

3. 획득한 runningTopic을 구독하여 실시간 좌표를 수신받습니다.

## 📚 기타
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start/end run REST endpoints with publish address for live location; end saves summary, metrics and track.
  * Real-time per-run location sharing via WebSocket, broadcasting live location updates.
  * Responses include run IDs, status, and timestamps for start/end events.
  * Added persistence, domain services, and standardized running error codes.

* **Chores**
  * CI workflow: minor environment formatting normalization.
  * Config: signup token TTL is now nullable (may require config update).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->