### PR TITLE
Feat: 런닝 세션 API 및 실시간 위치 공유 기능 구현

### DIFF
--- a/src/main/java/com/runky/running/api/RunningApiSpec.java
+++ b/src/main/java/com/runky/running/api/RunningApiSpec.java
@@ -1,0 +1,28 @@
+package com.runky.running.api;
+
+import com.runky.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Running API", description = "Runky Running API입니다.")
+public interface RunningApiSpec {
+
+	@Operation(summary = "런닝 시작", description = "런닝 세션을 시작하고, 실시간 위치를 전송할 WebSocket 주소를 반환합니다.")
+	@Parameter(name = "X-USER-ID", description = "사용자 ID", required = true, in = ParameterIn.HEADER, schema = @Schema(type = "integer", format = "int64"))
+	ApiResponse<RunningResponse.Start> start(
+		Long userId
+	);
+
+	@Operation(summary = "런닝 종료", description = "런닝을 종료하고 전체 기록을 저장합니다.")
+	@Parameter(name = "X-USER-ID", description = "사용자 ID", required = true, in = ParameterIn.HEADER, schema = @Schema(type = "integer", format = "int64"))
+	ApiResponse<RunningResponse.End> end(
+		Long userId,
+		@Schema(description = "종료할 런닝 ID") Long runningId,
+		@Schema(description = "런닝 요약 및 트랙 정보") RunningRequest.End request
+	);
+}
+

--- a/src/main/java/com/runky/running/api/RunningController.java
+++ b/src/main/java/com/runky/running/api/RunningController.java
@@ -1,0 +1,45 @@
+package com.runky.running.api;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.runky.global.response.ApiResponse;
+import com.runky.running.application.RunningCriteria;
+import com.runky.running.application.RunningFacade;
+import com.runky.running.application.RunningResult;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/runnings")
+@RequiredArgsConstructor
+public class RunningController implements RunningApiSpec {
+
+	private final RunningFacade runningFacade;
+
+	@Override
+	@PostMapping("/start")
+	public ApiResponse<RunningResponse.Start> start(@RequestHeader("X-USER-ID") Long userId) {
+		RunningResult.Start result = runningFacade.start(new RunningCriteria.Start(userId));
+
+		String publish = "/app/runnings/" + result.runningId() + "/location";
+
+		RunningResponse.Start response = RunningResponse.Start.from(publish, result);
+		return ApiResponse.success(response);
+	}
+
+	@Override
+	@PostMapping("/{runningId}/end")
+	public ApiResponse<RunningResponse.End> end(@RequestHeader("X-USER-ID") Long userId, @PathVariable Long runningId,
+		@RequestBody RunningRequest.End request) {
+		RunningCriteria.End criteria = request.toCriteria(userId, runningId);
+		RunningResult.End result = runningFacade.end(criteria);
+
+		RunningResponse.End response = RunningResponse.End.from(result);
+		return ApiResponse.success(response);
+	}
+}

--- a/src/main/java/com/runky/running/api/RunningLocationWsApiSpec.java
+++ b/src/main/java/com/runky/running/api/RunningLocationWsApiSpec.java
@@ -1,0 +1,23 @@
+package com.runky.running.api;
+
+/**
+ * 실시간 런닝 위치 공유 WebSocket API 명세
+ */
+public interface RunningLocationWsApiSpec {
+
+	/**
+	 * 클라이언트로부터 실시간 위치 정보를 수신하여 해당 런닝 세션을 구독하는 모든 클라이언트에게 브로드캐스팅합니다.
+	 * <p>
+	 * - <b>Publish Destination</b>: /app/runnings/{runningId}/location
+	 * <p>
+	 * - <b>Subscribe Destination</b>: /topic/runnings/{runningId}
+	 *
+	 * @param runningId 런닝 세션 ID
+	 * @param payload   위치 정보 메시지 (runnerId, x, y, timestamp)
+	 * @return 브로드캐스팅될 RoomEvent 객체
+	 */
+	RunningLocationWsController.RoomEvent publish(
+		Long runningId,
+		RunningLocationWsController.LocationMessage payload
+	);
+}

--- a/src/main/java/com/runky/running/api/RunningLocationWsController.java
+++ b/src/main/java/com/runky/running/api/RunningLocationWsController.java
@@ -1,0 +1,23 @@
+package com.runky.running.api;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class RunningLocationWsController implements RunningLocationWsApiSpec {
+
+	@MessageMapping("/runnings/{runningId}/location")
+	@SendTo("/topic/runnings/{runningId}")
+	public RoomEvent publish(@DestinationVariable Long runningId, @Payload LocationMessage payload) {
+		return new RoomEvent("LOCATION", payload.runnerId(), payload.x(), payload.y(), payload.timestamp());
+	}
+
+	public record LocationMessage(Long runnerId, double x, double y, long timestamp) {
+	}
+
+	public record RoomEvent(String type, Long runnerId, Double x, Double y, long timestamp) {
+	}
+}

--- a/src/main/java/com/runky/running/api/RunningRequest.java
+++ b/src/main/java/com/runky/running/api/RunningRequest.java
@@ -1,0 +1,45 @@
+package com.runky.running.api;
+
+import com.runky.running.application.RunningCriteria;
+
+public sealed interface RunningRequest {
+
+	record End(
+		Summary summary,
+		Track track
+	) implements RunningRequest {
+		RunningCriteria.End toCriteria(Long runnerId, Long runningId) {
+			return new RunningCriteria.End(
+				runnerId,
+				runningId,
+				summary.totalDistanceMinutes,
+				summary.durationSeconds,
+				summary.avgSpeedMPS,
+				track.format,
+				track.points,
+				track.pointCount
+			);
+		}
+
+		record Summary(
+			Double totalDistanceMinutes,
+			Long durationSeconds,
+			Double avgSpeedMPS
+		) {
+		}
+
+		record Track(
+			String format,
+			String points,
+			int pointCount
+		) {
+		}
+
+		record Point(
+			Double lat,
+			Double lng,
+			Long timestamp
+		) {
+		}
+	}
+}

--- a/src/main/java/com/runky/running/api/RunningResponse.java
+++ b/src/main/java/com/runky/running/api/RunningResponse.java
@@ -1,0 +1,23 @@
+package com.runky.running.api;
+
+import java.time.LocalDateTime;
+
+import com.runky.running.application.RunningResult;
+
+public sealed interface RunningResponse {
+
+	record Start(Long runningId, Long runnerId, String status, String publishDestination, LocalDateTime startedAt)
+		implements RunningResponse {
+		static Start from(String pub, RunningResult.Start result) {
+			return new Start(result.runningId(), result.runnerId(), result.status(), pub, result.startedAt());
+		}
+	}
+
+	record End(Long runningId, Long runnerId, String string, LocalDateTime startedAt, LocalDateTime endedAt)
+		implements RunningResponse {
+		static End from(RunningResult.End result) {
+			return new End(result.runningId(), result.runnerId(), result.status(), result.startedAt(),
+				result.endedAt());
+		}
+	}
+}

--- a/src/main/java/com/runky/running/application/RunningCriteria.java
+++ b/src/main/java/com/runky/running/application/RunningCriteria.java
@@ -1,0 +1,32 @@
+package com.runky.running.application;
+
+import com.runky.running.domain.RunningCommand;
+
+public sealed interface RunningCriteria {
+
+	record Start(
+		Long runnerId
+	) {
+		RunningCommand.Start toCommand() {
+			return new RunningCommand.Start(runnerId);
+		}
+	}
+
+	record End(
+		Long runningId,
+		Long runnerId,
+		Double totalDistanceMinutes,
+		Long durationSeconds,
+		Double avgSpeedMPS,
+		String format,
+		String points,
+		int pointCount
+
+	) implements RunningCriteria {
+		RunningCommand.End toCommand() {
+			return new RunningCommand.End(
+				runningId, runnerId, totalDistanceMinutes, durationSeconds, avgSpeedMPS, format, points, pointCount
+			);
+		}
+	}
+}

--- a/src/main/java/com/runky/running/application/RunningFacade.java
+++ b/src/main/java/com/runky/running/application/RunningFacade.java
@@ -1,0 +1,28 @@
+package com.runky.running.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.runky.running.domain.RunningInfo;
+import com.runky.running.domain.RunningService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RunningFacade {
+	private final RunningService runningService;
+
+	@Transactional
+	public RunningResult.Start start(RunningCriteria.Start criteria) {
+		RunningInfo.Start info = runningService.start(criteria.toCommand());
+		return RunningResult.Start.from(info);
+	}
+
+	@Transactional
+	public RunningResult.End end(RunningCriteria.End criteria) {
+		RunningInfo.End info = runningService.end(criteria.toCommand());
+		return RunningResult.End.from(info);
+	}
+
+}

--- a/src/main/java/com/runky/running/application/RunningResult.java
+++ b/src/main/java/com/runky/running/application/RunningResult.java
@@ -1,0 +1,34 @@
+package com.runky.running.application;
+
+import java.time.LocalDateTime;
+
+import com.runky.running.domain.RunningInfo;
+
+public sealed interface RunningResult {
+
+	record Start(Long runningId, Long runnerId, String status, LocalDateTime startedAt) implements RunningResult {
+		public static Start from(RunningInfo.Start info) {
+			return new Start(
+				info.runningId(),
+				info.runnerId(),
+				info.status(),
+				info.startedAt()
+			);
+		}
+	}
+
+	record End(Long runningId, Long runnerId, String status, LocalDateTime startedAt, LocalDateTime endedAt
+	) implements RunningResult {
+
+		public static End from(RunningInfo.End info) {
+			return new End(
+				info.runningId(),
+				info.runnerId(),
+				info.status(),
+				info.startedAt(),
+				info.endedAt()
+			);
+		}
+	}
+
+}

--- a/src/main/java/com/runky/running/domain/Running.java
+++ b/src/main/java/com/runky/running/domain/Running.java
@@ -1,0 +1,79 @@
+package com.runky.running.domain;
+
+import java.time.LocalDateTime;
+
+import com.runky.global.error.GlobalException;
+import com.runky.running.error.RunningErrorCode;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "runnings")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class Running {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "runner_id", nullable = false)
+	private Long runnerId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 16)
+	private Status status; // RUNNING, FINISHED
+
+	@Column(name = "started_at", nullable = false)
+	private LocalDateTime startedAt;
+
+	@Column(name = "ended_at", nullable = true)
+	private LocalDateTime endedAt;
+
+	@Column(name = "total_distance_minutes")
+	private Double totalDistanceMinutes;
+
+	@Column(name = "duration_seconds")
+	private Long durationSeconds;
+
+	@Column(name = "avg_speed_mps")
+	private Double avgSpeedMPS;
+
+	public static Running start(Long runningId, LocalDateTime now) {
+		return Running.builder()
+			.runnerId(runningId)
+			.status(Status.RUNNING)
+			.startedAt(now)
+			.build();
+	}
+
+	public boolean isActive() {
+		return this.status == Status.RUNNING && this.endedAt == null;
+	}
+
+	public void finish(double totalDistanceMinutes, long durationSeconds, Double avgSpeedMps) {
+		if (this.status != Status.RUNNING) {
+			throw new GlobalException(RunningErrorCode.NOT_ACTIVE_RUNNING);
+		}
+		this.endedAt = LocalDateTime.now();
+		this.status = Status.FINISHED;
+		this.totalDistanceMinutes = totalDistanceMinutes;
+		this.durationSeconds = durationSeconds;
+		this.avgSpeedMPS = avgSpeedMps;
+	}
+
+	public enum Status {RUNNING, FINISHED}
+}

--- a/src/main/java/com/runky/running/domain/RunningCommand.java
+++ b/src/main/java/com/runky/running/domain/RunningCommand.java
@@ -1,0 +1,20 @@
+package com.runky.running.domain;
+
+public sealed interface RunningCommand {
+	record Start(
+		Long runnerId
+	) implements RunningCommand {
+	}
+
+	record End(
+		Long runningId,
+		Long runnerId,
+		Double totalDistanceMinutes,
+		Long durationSeconds,
+		Double avgSpeedMPS,
+		String format,
+		String points,
+		int pointCount
+	) implements RunningCommand {
+	}
+}

--- a/src/main/java/com/runky/running/domain/RunningInfo.java
+++ b/src/main/java/com/runky/running/domain/RunningInfo.java
@@ -1,0 +1,21 @@
+package com.runky.running.domain;
+
+import java.time.LocalDateTime;
+
+public sealed interface RunningInfo {
+
+	record Start(Long runningId, Long runnerId, String status, LocalDateTime startedAt) implements RunningInfo {
+		static Start from(Running running) {
+			return new Start(
+				running.getId(),
+				running.getRunnerId(),
+				running.getStatus().toString(),
+				running.getStartedAt()
+			);
+		}
+	}
+
+	record End(Long runningId, Long runnerId, String status, LocalDateTime startedAt, LocalDateTime endedAt)
+		implements RunningInfo {
+	}
+}

--- a/src/main/java/com/runky/running/domain/RunningRepository.java
+++ b/src/main/java/com/runky/running/domain/RunningRepository.java
@@ -1,0 +1,11 @@
+package com.runky.running.domain;
+
+import java.util.Optional;
+
+public interface RunningRepository {
+	boolean existsByRunnerIdAndEndedAtIsNull(Long runnerId);
+
+	Optional<Running> findByIdAndRunnerId(Long id, Long runnerId);
+
+	Running save(Running running);
+}

--- a/src/main/java/com/runky/running/domain/RunningService.java
+++ b/src/main/java/com/runky/running/domain/RunningService.java
@@ -1,0 +1,59 @@
+package com.runky.running.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.runky.global.error.GlobalException;
+import com.runky.running.error.RunningErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RunningService {
+
+	private final RunningRepository runningRepository;
+	private final ApplicationEventPublisher events;
+	private final RunningTrackRepository trackRepository;
+
+	@Transactional
+	public RunningInfo.Start start(RunningCommand.Start command) {
+		if (runningRepository.existsByRunnerIdAndEndedAtIsNull(command.runnerId())) {
+			throw new GlobalException(RunningErrorCode.NOT_FOUND_RUNNING);
+		}
+
+		Running running = runningRepository.save(Running.start(command.runnerId(), LocalDateTime.now()));
+		return RunningInfo.Start.from(running);
+	}
+
+	@Transactional
+	public RunningInfo.End end(RunningCommand.End command) {
+		Running running = runningRepository.findByIdAndRunnerId(command.runningId(), command.runnerId())
+			.orElseThrow(() -> new GlobalException(RunningErrorCode.NOT_FOUND_RUNNING));
+
+		if (!running.isActive()) {
+			throw new GlobalException(RunningErrorCode.NOT_ACTIVE_RUNNING);
+		}
+
+		running.finish(command.totalDistanceMinutes(), command.durationSeconds(), command.avgSpeedMPS());
+		runningRepository.save(running);
+
+		if (trackRepository.existsByRunningId(command.runningId())) {
+			throw new GlobalException(RunningErrorCode.TRACK_ALREADY_EXISTS);
+		}
+
+		RunningTrack runningTrack = new RunningTrack(
+			running,
+			command.format(),
+			command.points(),
+			command.pointCount()
+		);
+		trackRepository.save(runningTrack);
+
+		return new RunningInfo.End(running.getId(), running.getRunnerId(), running.getStatus().toString(),
+			running.getStartedAt(), running.getEndedAt());
+	}
+}

--- a/src/main/java/com/runky/running/domain/RunningTrack.java
+++ b/src/main/java/com/runky/running/domain/RunningTrack.java
@@ -1,0 +1,48 @@
+package com.runky.running.domain;
+
+import com.runky.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "running_tracks")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RunningTrack extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "running_id", nullable = false)
+	private Running running;
+
+	@Column(name = "format", nullable = false)
+	private String format;
+
+	@Column(columnDefinition = "TEXT", name = "points", nullable = false)
+	private String points;
+
+	@Column(name = "point_count", nullable = false)
+	private int pointCount;
+
+	@Builder
+	public RunningTrack(final Running running, final String points, final String format, final int pointCount) {
+		this.running = running;
+		this.points = points;
+		this.format = format;
+		this.pointCount = pointCount;
+	}
+}

--- a/src/main/java/com/runky/running/domain/RunningTrackRepository.java
+++ b/src/main/java/com/runky/running/domain/RunningTrackRepository.java
@@ -1,0 +1,8 @@
+package com.runky.running.domain;
+
+public interface RunningTrackRepository {
+	boolean existsByRunningId(Long runningId);
+
+	void save(RunningTrack runningTrack);
+
+}

--- a/src/main/java/com/runky/running/error/RunningErrorCode.java
+++ b/src/main/java/com/runky/running/error/RunningErrorCode.java
@@ -1,0 +1,35 @@
+package com.runky.running.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.runky.global.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RunningErrorCode implements ErrorCode {
+	/* R1xx: Running 상태/조회 */
+	NOT_FOUND_RUNNING(HttpStatus.NOT_FOUND, "R101", "런닝을 찾을 수 없습니다."),
+	ALREADY_ACTIVE_RUNNING(HttpStatus.CONFLICT, "R102", "이미 진행 중인 런닝이 있습니다."),
+	NOT_ACTIVE_RUNNING(HttpStatus.CONFLICT, "R103", "시작 상태가 아니므로 종료할 수 없습니다."),
+
+	/* R2xx: Running Track 저장/포맷 */
+	TRACK_ALREADY_EXISTS(HttpStatus.CONFLICT, "R201", "이미 트랙이 저장되어 있습니다."),
+	INVALID_TRACK_FORMAT(HttpStatus.BAD_REQUEST, "R202", "지원하지 않는 트랙 포맷입니다."),
+	EMPTY_TRACK_POINTS(HttpStatus.BAD_REQUEST, "R203", "트랙 좌표가 비어있습니다."),
+	EXCESSIVE_TRACK_POINTS(HttpStatus.UNPROCESSABLE_ENTITY, "R204", "트랙 좌표 개수가 허용 범위를 초과했습니다."),
+
+	/* R3xx: 권한/입력 검증 */
+	FORBIDDEN_RUNNING_ACCESS(HttpStatus.FORBIDDEN, "R301", "해당 런닝에 접근 권한이 없습니다."),
+	INVALID_END_METRICS(HttpStatus.BAD_REQUEST, "R302", "종료 메트릭 값이 올바르지 않습니다."),
+
+	/* R9xx: 인프라/제약 위반/기타 */
+	UNIQUE_ACTIVE_CONSTRAINT_VIOLATED(HttpStatus.CONFLICT, "R901", "활성 런닝 중복 제약에 위배되었습니다."),
+	EVENT_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "R902", "이벤트 발행에 실패했습니다.");
+
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/runky/running/infra/RunningJpaRepository.java
+++ b/src/main/java/com/runky/running/infra/RunningJpaRepository.java
@@ -1,0 +1,14 @@
+package com.runky.running.infra;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.runky.running.domain.Running;
+
+public interface RunningJpaRepository extends JpaRepository<Running, Long> {
+	boolean existsByRunnerIdAndEndedAtIsNull(Long runnerId);
+
+	Optional<Running> findByIdAndRunnerId(Long id, Long runnerId);
+
+}

--- a/src/main/java/com/runky/running/infra/RunningRepositoryImpl.java
+++ b/src/main/java/com/runky/running/infra/RunningRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.runky.running.infra;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.runky.running.domain.Running;
+import com.runky.running.domain.RunningRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RunningRepositoryImpl implements RunningRepository {
+	private final RunningJpaRepository jpaRepository;
+
+	@Override
+	public boolean existsByRunnerIdAndEndedAtIsNull(final Long runnerId) {
+		return jpaRepository.existsByRunnerIdAndEndedAtIsNull(runnerId);
+	}
+
+	@Override
+	public Optional<Running> findByIdAndRunnerId(final Long id, final Long runnerId) {
+		return jpaRepository.findByIdAndRunnerId(id, runnerId);
+	}
+
+	@Override
+	public Running save(final Running running) {
+		jpaRepository.save(running);
+		return running;
+	}
+}

--- a/src/main/java/com/runky/running/infra/RunningTrackJpaRepository.java
+++ b/src/main/java/com/runky/running/infra/RunningTrackJpaRepository.java
@@ -1,0 +1,9 @@
+package com.runky.running.infra;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.runky.running.domain.RunningTrack;
+
+public interface RunningTrackJpaRepository extends JpaRepository<RunningTrack, Long> {
+	boolean existsByRunningId(Long runningId);
+}

--- a/src/main/java/com/runky/running/infra/RunningTrackRepositoryImpl.java
+++ b/src/main/java/com/runky/running/infra/RunningTrackRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.runky.running.infra;
+
+import org.springframework.stereotype.Repository;
+
+import com.runky.running.domain.RunningTrack;
+import com.runky.running.domain.RunningTrackRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RunningTrackRepositoryImpl implements RunningTrackRepository {
+	private final RunningTrackJpaRepository jpaRepository;
+
+	@Override
+	public boolean existsByRunningId(final Long runningId) {
+		return jpaRepository.existsByRunningId(runningId);
+	}
+
+	@Override
+	public void save(final RunningTrack runningTrack) {
+		jpaRepository.save(runningTrack);
+	}
+}


### PR DESCRIPTION
## ✨ 이슈 내용
> 런닝 세션 API 및 실시간 위치 공유 기능 구현

## 💡 작업 내용
- [ ] 런닝 시작 API 
  - 런닝 세션을 시작하고, 클라이언트가 위치를 발행할 웹소캣 주소를 응답에 포함합니다.
- [ ] 런닝 종료 API
  - 런닝을 종료하고, 전체 런닝 요약 및 트랙 데이터를 저장합니다.

- [ ] 런닝 웹소캣 API
  -  //app/runnings/{runningId}/location 으로 들어온 실시간 좌표 메시지를 수신합니다. 
  - 수신된 좌표는 /topic/runnings/{runningId} 토픽을 구독하는 모든 클라이언트에게 브로드캐스팅합니다.

## 📌 참고 사항
-  STOMP api에서 SimpMessagingTemplate 대신 @SendTo를 사용하여 코드를 간소화했습니다.
-  이번 PR에서 테스트 코드는 없습니다.
-  다음 기능으로 알림 기능을 추가합니다.

## 프론트 입장에서 런닝 시작~ 종료 플로우

### 러너 입장
1. POST api/runnings/start 요청시 브로드캐스팅주소 응답 수신(publishDestination)
2. WS 연결 
3. publishDestinantion으로 좌표 매초 전송
4. 종료 시 POST /api/runnings/{id}/end

### 크루원 입장
1. FCM 알림 클릭 → runningTopic 획득
2. WS 연결
3. runningTopic 구독 요청 → 좌표 수신 받음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Start and end running sessions via REST endpoints; provides session IDs, status, and publish destination.
  - Real-time location broadcasting over WebSocket with publish/subscribe destinations for running sessions.

- **Documentation**
  - API docs updated with operation details and required X-USER-ID header.
  - WebSocket usage documented with message and topic semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->