### PR TITLE
Feat: FCM 디바이스 토큰 생성,삭제 API 구현 및 조회 서비스 구현

### DIFF
--- a/src/main/java/com/runky/notification/api/DeviceTokenApiSpec.java
+++ b/src/main/java/com/runky/notification/api/DeviceTokenApiSpec.java
@@ -1,0 +1,51 @@
+package com.runky.notification.api;
+
+import com.runky.global.response.ApiResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Device Token API", description = "FCM 디바이스 토큰 등록/삭제 API")
+public interface DeviceTokenApiSpec {
+
+	@Operation(
+		summary = "디바이스 토큰 등록",
+		description = """
+			사용자의 FCM 디바이스 토큰을 등록합니다.
+			- 이미 등록된 토큰(유니크 키 충돌)일 경우 409 응답으로 처리됩니다.
+			"""
+	)
+	@Parameter(
+		name = "X-USER-ID",
+		description = "사용자 ID",
+		required = true,
+		in = ParameterIn.HEADER,
+		schema = @Schema(type = "integer", format = "int64", example = "123")
+	)
+	ApiResponse<Void> register(
+		Long userId,
+		@Schema(description = "디바이스 토큰 등록 요청 바디") DeviceTokenRequest.Register request
+	);
+
+	@Operation(
+		summary = "디바이스 토큰 삭제",
+		description = """
+			사용자의 FCM 디바이스 토큰을 삭제합니다.
+			- 요청된 토큰이 존재하지 않으면 404 또는 사내 규약의 에러 코드로 응답됩니다.
+			"""
+	)
+	@Parameter(
+		name = "X-USER-ID",
+		description = "사용자 ID",
+		required = true,
+		in = ParameterIn.HEADER,
+		schema = @Schema(type = "integer", format = "int64", example = "123")
+	)
+	ApiResponse<DeviceTokenResponse.Delete> delete(
+		Long userId,
+		@Schema(description = "디바이스 토큰 삭제 요청 바디") DeviceTokenRequest.Delete request
+	);
+}

--- a/src/main/java/com/runky/notification/api/DeviceTokenController.java
+++ b/src/main/java/com/runky/notification/api/DeviceTokenController.java
@@ -1,0 +1,40 @@
+package com.runky.notification.api;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.runky.global.response.ApiResponse;
+import com.runky.notification.application.DeviceTokenFacade;
+import com.runky.notification.application.DeviceTokenResult;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/device-tokens")
+@RequiredArgsConstructor
+public class DeviceTokenController {
+
+	private final DeviceTokenFacade deviceTokenFacade;
+
+	@PostMapping
+	public ApiResponse<Void> register(
+		@RequestHeader("X-USER-ID") Long userId,
+		@RequestBody DeviceTokenRequest.Register request
+	) {
+		deviceTokenFacade.register(request.toCriteria(userId));
+		return ApiResponse.ok();
+	}
+
+	@DeleteMapping
+	public ApiResponse<DeviceTokenResponse.Delete> delete(
+		@RequestHeader("X-USER-ID") Long userId,
+		@RequestBody DeviceTokenRequest.Delete request
+	) {
+		DeviceTokenResult.Delete result = deviceTokenFacade.delete(request.toCriteria(userId));
+		return ApiResponse.success(new DeviceTokenResponse.Delete(result.count()));
+	}
+}

--- a/src/main/java/com/runky/notification/api/DeviceTokenController.java
+++ b/src/main/java/com/runky/notification/api/DeviceTokenController.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/device-tokens")
 @RequiredArgsConstructor
-public class DeviceTokenController {
+public class DeviceTokenController implements DeviceTokenApiSpec {
 
 	private final DeviceTokenFacade deviceTokenFacade;
 

--- a/src/main/java/com/runky/notification/api/DeviceTokenRequest.java
+++ b/src/main/java/com/runky/notification/api/DeviceTokenRequest.java
@@ -1,0 +1,23 @@
+package com.runky.notification.api;
+
+import org.aspectj.weaver.patterns.IToken;
+
+import com.runky.notification.application.DeviceTokenCriteria;
+import com.runky.notification.domain.push.DeviceToken;
+
+public sealed interface DeviceTokenRequest {
+
+	record Register(String token) implements DeviceTokenRequest{
+		DeviceTokenCriteria.Register toCriteria(Long memberId){
+			return new DeviceTokenCriteria.Register(memberId,token);
+		}
+	}
+
+	record Delete(String token) implements DeviceTokenRequest{
+		DeviceTokenCriteria.Delete toCriteria(Long memberId){
+			return new DeviceTokenCriteria.Delete(memberId,token);
+
+		}
+	}
+
+}

--- a/src/main/java/com/runky/notification/api/DeviceTokenResponse.java
+++ b/src/main/java/com/runky/notification/api/DeviceTokenResponse.java
@@ -1,0 +1,8 @@
+package com.runky.notification.api;
+
+public sealed interface DeviceTokenResponse {
+
+	record Delete(int count) implements DeviceTokenResponse {
+	}
+
+}

--- a/src/main/java/com/runky/notification/application/DeviceTokenCriteria.java
+++ b/src/main/java/com/runky/notification/application/DeviceTokenCriteria.java
@@ -1,0 +1,14 @@
+package com.runky.notification.application;
+
+import com.runky.notification.domain.push.DeviceToken;
+
+public sealed interface DeviceTokenCriteria {
+
+	record Register(Long memberId,String token)implements DeviceTokenCriteria{
+
+	}
+
+	record Delete(Long memberId,String token)implements DeviceTokenCriteria{
+
+	}
+}

--- a/src/main/java/com/runky/notification/application/DeviceTokenFacade.java
+++ b/src/main/java/com/runky/notification/application/DeviceTokenFacade.java
@@ -1,0 +1,30 @@
+package com.runky.notification.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.runky.notification.domain.push.DeviceTokenCommand;
+import com.runky.notification.domain.push.DeviceTokenInfo;
+import com.runky.notification.domain.push.DeviceTokenService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeviceTokenFacade {
+
+	private final DeviceTokenService deviceTokenService;
+
+	@Transactional
+	public void register(DeviceTokenCriteria.Register criteria) {
+		deviceTokenService.register(new DeviceTokenCommand.Register(criteria.memberId(), criteria.token()));
+	}
+
+	@Transactional
+	public DeviceTokenResult.Delete delete(DeviceTokenCriteria.Delete criteria) {
+		DeviceTokenInfo.Delete info = deviceTokenService.delete(
+			new DeviceTokenCommand.Delete(criteria.memberId(), criteria.token()));
+
+		return new DeviceTokenResult.Delete(info.count());
+	}
+}

--- a/src/main/java/com/runky/notification/application/DeviceTokenResult.java
+++ b/src/main/java/com/runky/notification/application/DeviceTokenResult.java
@@ -1,0 +1,8 @@
+package com.runky.notification.application;
+
+public sealed interface DeviceTokenResult {
+
+	record Delete(int count) implements DeviceTokenResult {
+	}
+
+}

--- a/src/main/java/com/runky/notification/domain/push/DeviceToken.java
+++ b/src/main/java/com/runky/notification/domain/push/DeviceToken.java
@@ -1,0 +1,54 @@
+package com.runky.notification.domain.push;
+
+import com.runky.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "device_tokens", indexes = @Index(name = "idx_member_token", columnList = "member_id, token"))
+public class DeviceToken extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "member_id", nullable = false)
+	private Long memberId;
+
+	@Column(name = "token", nullable = false, length = 512, unique = true)
+	private String token;
+
+	@Column(name = "active", nullable = false)
+	private boolean active;
+
+	public static DeviceToken register(Long memberId, String token) {
+		return DeviceToken.builder()
+			.memberId(memberId)
+			.token(token)
+			.active(true)
+			.build();
+	}
+
+	public void reactivate() {
+		this.active = true;
+	}
+
+	public void deactivate() {
+		this.active = false;
+	}
+}

--- a/src/main/java/com/runky/notification/domain/push/DeviceTokenCommand.java
+++ b/src/main/java/com/runky/notification/domain/push/DeviceTokenCommand.java
@@ -1,0 +1,15 @@
+package com.runky.notification.domain.push;
+
+public sealed interface DeviceTokenCommand {
+
+	// Command //
+	record Register(Long memberId, String token) implements DeviceTokenCommand {
+	}
+
+	record Delete(Long memberId, String token) implements DeviceTokenCommand {
+	}
+
+	// Query //
+	record Find(Long memberId, String token) implements DeviceTokenCommand {
+	}
+}

--- a/src/main/java/com/runky/notification/domain/push/DeviceTokenInfo.java
+++ b/src/main/java/com/runky/notification/domain/push/DeviceTokenInfo.java
@@ -1,0 +1,16 @@
+package com.runky.notification.domain.push;
+
+public sealed interface DeviceTokenInfo {
+
+	record Delete(int count) implements DeviceTokenInfo {
+	}
+
+	record View(Long id, Long memberId, String token, boolean active) implements DeviceTokenInfo {
+
+	}
+
+	record Existence(boolean exists) implements DeviceTokenInfo {
+
+	}
+
+}

--- a/src/main/java/com/runky/notification/domain/push/DeviceTokenRepository.java
+++ b/src/main/java/com/runky/notification/domain/push/DeviceTokenRepository.java
@@ -1,0 +1,21 @@
+package com.runky.notification.domain.push;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DeviceTokenRepository {
+	/** 상태 변경 중심 **/
+	DeviceToken save(DeviceToken token);
+
+	int deleteByMemberIdAndToken(Long memberId, String token);
+
+	void deactivateTokens(List<String> tokens);
+
+	Optional<DeviceToken> findByMemberIdAndToken(Long memberId, String token); // 운영/정합 목적
+
+	/** 조회(읽기) 중심 **/
+	List<String> findActiveTokensByMemberIds(List<Long> memberIds);
+
+	boolean existsActiveByMemberIdAndToken(Long memberId, String token);
+
+}

--- a/src/main/java/com/runky/notification/domain/push/DeviceTokenService.java
+++ b/src/main/java/com/runky/notification/domain/push/DeviceTokenService.java
@@ -42,7 +42,7 @@ public class DeviceTokenService {
 	public DeviceTokenInfo.View view(DeviceTokenCommand.Find cmd) {
 		return deviceTokenRepository.findByMemberIdAndToken(cmd.memberId(), cmd.token())
 			.map(dt -> new DeviceTokenInfo.View(dt.getId(), dt.getMemberId(), dt.getToken(), dt.isActive()))
-			.orElseThrow(() -> new GlobalException(NotificationErrorCode.NOT_EXIST_TO_DELETE_DEVICE_TOKEN));
+			.orElseThrow(() -> new GlobalException(NotificationErrorCode.NOT_FOUND_DEVICE_TOKEN));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/runky/notification/domain/push/DeviceTokenService.java
+++ b/src/main/java/com/runky/notification/domain/push/DeviceTokenService.java
@@ -1,0 +1,60 @@
+package com.runky.notification.domain.push;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.runky.global.error.GlobalException;
+import com.runky.notification.error.NotificationErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeviceTokenService {
+
+	private final DeviceTokenRepository deviceTokenRepository;
+
+	@Transactional
+	public void register(DeviceTokenCommand.Register command) {
+		DeviceToken deviceToken = DeviceToken.register(command.memberId(), command.token());
+		try {
+			deviceTokenRepository.save(deviceToken);
+		} catch (DataIntegrityViolationException e) {
+			if (isUniqueViolationOnToken(e)) {
+				throw new GlobalException(NotificationErrorCode.DUPLICATE_UNIQUE_KEY_DEVICE_TOKEN);
+			}
+			throw e;
+		}
+	}
+
+	@Transactional
+	public DeviceTokenInfo.Delete delete(DeviceTokenCommand.Delete command) {
+		int deletedCount = deviceTokenRepository.deleteByMemberIdAndToken(command.memberId(), command.token());
+
+		if (deletedCount == 0) {
+			throw new GlobalException(NotificationErrorCode.NOT_EXIST_TO_DELETE_DEVICE_TOKEN);
+		}
+		return new DeviceTokenInfo.Delete(deletedCount);
+	}
+
+	@Transactional(readOnly = true)
+	public DeviceTokenInfo.View view(DeviceTokenCommand.Find cmd) {
+		return deviceTokenRepository.findByMemberIdAndToken(cmd.memberId(), cmd.token())
+			.map(dt -> new DeviceTokenInfo.View(dt.getId(), dt.getMemberId(), dt.getToken(), dt.isActive()))
+			.orElseThrow(() -> new GlobalException(NotificationErrorCode.NOT_EXIST_TO_DELETE_DEVICE_TOKEN));
+	}
+
+	@Transactional(readOnly = true)
+	public DeviceTokenInfo.Existence isExists(DeviceTokenCommand.Find command) {
+		boolean exists = deviceTokenRepository.existsActiveByMemberIdAndToken(command.memberId(), command.token());
+		return new DeviceTokenInfo.Existence((exists));
+	}
+
+	private boolean isUniqueViolationOnToken(DataIntegrityViolationException e) {
+		Throwable root = org.springframework.core.NestedExceptionUtils.getMostSpecificCause(e);
+		String msg = (root != null ? root.getMessage() : e.getMessage());
+		return msg != null && msg.contains("ux_device_token_token");
+	}
+
+}

--- a/src/main/java/com/runky/notification/error/NotificationErrorCode.java
+++ b/src/main/java/com/runky/notification/error/NotificationErrorCode.java
@@ -1,0 +1,28 @@
+package com.runky.notification.error;
+
+import org.springframework.http.HttpStatus;
+
+import com.runky.global.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements ErrorCode {
+
+	/* NDT1xx: DeviceToken 상태/조회 */
+	NOT_FOUND_DEVICE_TOKEN(HttpStatus.NOT_FOUND, "NDT101", "디바이스 토큰을 찾을 수 없습니다."),
+	NOT_EXIST_TO_DELETE_DEVICE_TOKEN(HttpStatus.NOT_FOUND, "NDT102", "삭제할 디바이스 토큰이 존재하지 않습니다."),
+	ALREADY_REGISTERED_DEVICE_TOKEN(HttpStatus.CONFLICT, "NDT103", "이미 존재하는 디바이스 토큰 입니다."),
+	/* NDT2xx: DeviceToken  저장/포맷 */
+	DUPLICATE_UNIQUE_KEY_DEVICE_TOKEN(HttpStatus.CONFLICT, "NDT201", "같은 디바이스 토큰을 중복 저장할 수 없습니다."),
+
+
+	/* NDT3xx: 권한/입력 검증 */
+
+	/* NDT9xx: 인프라/제약 위반/기타 */;
+	private final HttpStatus status;
+	private final String code;
+	private final String message;
+}

--- a/src/main/java/com/runky/notification/infrastructure/push/DeviceTokenJpaRepository.java
+++ b/src/main/java/com/runky/notification/infrastructure/push/DeviceTokenJpaRepository.java
@@ -1,0 +1,38 @@
+package com.runky.notification.infrastructure.push;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.runky.notification.domain.push.DeviceToken;
+
+interface DeviceTokenJpaRepository extends JpaRepository<DeviceToken, Long> {
+
+	@Query("""
+		  select dt.token
+		  from DeviceToken dt
+		  where dt.memberId in :memberIds and dt.active = true
+		""")
+	List<String> findActiveTokensByMemberIds(@Param("memberIds") List<Long> memberIds);
+
+	@Query("""
+		  select case when count(dt) > 0 then true else false end
+		  from DeviceToken dt
+		  where dt.memberId = :memberId and dt.token = :token and dt.active = true
+		""")
+	boolean existsActiveByMemberIdAndToken(@Param("memberId") Long memberId, @Param("token") String token);
+
+	@Modifying
+	@Query("delete from DeviceToken dt where dt.memberId = :memberId and dt.token = :token")
+	int deleteByMemberIdAndToken(@Param("memberId") Long memberId, @Param("token") String token);
+
+	@Modifying
+	@Query("update DeviceToken dt set dt.active = false where dt.token in :tokens")
+	void deactivateTokens(@Param("tokens") List<String> tokens);
+
+	Optional<DeviceToken> findByMemberIdAndToken(Long memberId, String token);
+}

--- a/src/main/java/com/runky/notification/infrastructure/push/DeviceTokenRepositoryImpl.java
+++ b/src/main/java/com/runky/notification/infrastructure/push/DeviceTokenRepositoryImpl.java
@@ -1,0 +1,54 @@
+package com.runky.notification.infrastructure.push;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.runky.notification.domain.push.DeviceToken;
+import com.runky.notification.domain.push.DeviceTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeviceTokenRepositoryImpl implements DeviceTokenRepository {
+
+	private final DeviceTokenJpaRepository jpa;
+
+	/** 상태 변경 중심 **/
+
+	@Override
+	public DeviceToken save(final DeviceToken token) {
+		return jpa.save(token);
+	}
+
+	@Override
+	public int deleteByMemberIdAndToken(final Long memberId, final String token) {
+		return jpa.deleteByMemberIdAndToken(memberId, token);
+	}
+
+	@Override
+	public void deactivateTokens(final List<String> tokens) {
+		jpa.deactivateTokens(tokens);
+	}
+
+	@Override
+	public Optional<DeviceToken> findByMemberIdAndToken(final Long memberId, final String token) {
+		return jpa.findByMemberIdAndToken(memberId, token);
+	}
+
+	/** 조회(읽기) 중심 **/
+	@Override
+	public List<String> findActiveTokensByMemberIds(final List<Long> memberIds) {
+		return jpa.findActiveTokensByMemberIds(memberIds);
+	}
+
+	@Override
+	public boolean existsActiveByMemberIdAndToken(Long memberId, String token) {
+		return jpa.existsActiveByMemberIdAndToken(memberId, token);
+	}
+
+}

--- a/src/test/java/com/runky/crew/domain/CrewServiceTest.java
+++ b/src/test/java/com/runky/crew/domain/CrewServiceTest.java
@@ -1,14 +1,12 @@
 package com.runky.crew.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
-import com.runky.crew.error.CrewErrorCode;
-import com.runky.global.error.GlobalErrorCode;
-import com.runky.global.error.GlobalException;
 import java.util.List;
 import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -17,209 +15,213 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.runky.crew.error.CrewErrorCode;
+import com.runky.global.error.GlobalErrorCode;
+import com.runky.global.error.GlobalException;
+
 @ExtendWith(MockitoExtension.class)
 class CrewServiceTest {
 
-    @InjectMocks
-    private CrewService crewService;
-    @Mock
-    private CrewRepository crewRepository;
-    @Mock
-    private CodeGenerator codeGenerator;
+	@InjectMocks
+	private CrewService crewService;
+	@Mock
+	private CrewRepository crewRepository;
+	@Mock
+	private CodeGenerator codeGenerator;
 
-    @DisplayName("크루 생성 시,")
-    @Nested
-    class Create {
+	@DisplayName("크루 생성 시,")
+	@Nested
+	class Create {
 
-        @Test
-        @DisplayName("사용자의 크루 가입 수 정보가 없는 경우, NOT_FOUND 예외를 발생시킨다.")
-        void throwNotFoundException_whenMemberCrewCountNotFound() {
-            CrewCommand.Create command = new CrewCommand.Create(1L, "Test Crew");
-            given(crewRepository.findCountByMemberId(command.userId()))
-                    .willReturn(Optional.empty());
+		@Test
+		@DisplayName("사용자의 크루 가입 수 정보가 없는 경우, NOT_FOUND 예외를 발생시킨다.")
+		void throwNotFoundException_whenMemberCrewCountNotFound() {
+			CrewCommand.Create command = new CrewCommand.Create(1L, "Test Crew");
+			given(crewRepository.findCountByMemberId(command.userId()))
+				.willReturn(Optional.empty());
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.create(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.create(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
-        }
-    }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(GlobalErrorCode.NOT_FOUND));
+		}
+	}
 
-    @DisplayName("크루 가입 시,")
-    @Nested
-    class Join {
+	@DisplayName("크루 가입 시,")
+	@Nested
+	class Join {
 
-        @Test
-        @DisplayName("탈퇴했던 크루일 경우, 재가입 처리된다.")
-        void rejoinCrew_whenAlreadyJoined() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Crew"), new Code("ABC123"));
-            crew.joinMember(2L);
-            crew.leaveMember(2L);
-            given(crewRepository.findCrewByCode(crew.getCode()))
-                    .willReturn(Optional.of(crew));
-            given(crewRepository.findCountByMemberId(2L))
-                    .willReturn(Optional.of(CrewMemberCount.of(2L)));
-            CrewCommand.Join command = new CrewCommand.Join(2L, crew.getCode().value());
+		@Test
+		@DisplayName("탈퇴했던 크루일 경우, 재가입 처리된다.")
+		void rejoinCrew_whenAlreadyJoined() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Crew"), new Code("ABC123"));
+			crew.joinMember(2L);
+			crew.leaveMember(2L);
+			given(crewRepository.findCrewByCode(crew.getCode()))
+				.willReturn(Optional.of(crew));
+			given(crewRepository.findCountByMemberId(2L))
+				.willReturn(Optional.of(CrewMemberCount.of(2L)));
+			CrewCommand.Join command = new CrewCommand.Join(2L, crew.getCode().value());
 
-            Crew joinedCrew = crewService.join(command);
+			Crew joinedCrew = crewService.join(command);
 
-            assertThat(joinedCrew.getMember(2L).getRole()).isEqualTo(CrewMember.Role.MEMBER);
-            assertThat(joinedCrew.getMember(2L).isInCrew()).isTrue();
-        }
+			assertThat(joinedCrew.getMember(2L).getRole()).isEqualTo(CrewMember.Role.MEMBER);
+			assertThat(joinedCrew.getMember(2L).isInCrew()).isTrue();
+		}
 
-        @Test
-        @DisplayName("크루에 처음 가입하는 경우, 새로운 멤버로 추가된다.")
-        void joinCrew_whenFirstTimeJoining() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "New Crew"), new Code("XYZ789"));
-            given(crewRepository.findCrewByCode(crew.getCode()))
-                    .willReturn(Optional.of(crew));
-            given(crewRepository.findCountByMemberId(3L))
-                    .willReturn(Optional.of(CrewMemberCount.of(3L)));
-            CrewCommand.Join command = new CrewCommand.Join(3L, crew.getCode().value());
+		@Test
+		@DisplayName("크루에 처음 가입하는 경우, 새로운 멤버로 추가된다.")
+		void joinCrew_whenFirstTimeJoining() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "New Crew"), new Code("XYZ789"));
+			given(crewRepository.findCrewByCode(crew.getCode()))
+				.willReturn(Optional.of(crew));
+			given(crewRepository.findCountByMemberId(3L))
+				.willReturn(Optional.of(CrewMemberCount.of(3L)));
+			CrewCommand.Join command = new CrewCommand.Join(3L, crew.getCode().value());
 
-            Crew joinedCrew = crewService.join(command);
+			Crew joinedCrew = crewService.join(command);
 
-            assertThat(joinedCrew.getMember(3L).getRole()).isEqualTo(CrewMember.Role.MEMBER);
-            assertThat(joinedCrew.getMember(3L).isInCrew()).isTrue();
-        }
-    }
+			assertThat(joinedCrew.getMember(3L).getRole()).isEqualTo(CrewMember.Role.MEMBER);
+			assertThat(joinedCrew.getMember(3L).isInCrew()).isTrue();
+		}
+	}
 
-    @Nested
-    @DisplayName("크루 상세 조회 시,")
-    class Detail {
-        @Test
-        @DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
-        void throwNotFoundCrewException_whenCrewNotFound() {
-            CrewCommand.Detail command = new CrewCommand.Detail(1L, 2L);
-            given(crewRepository.findById(command.crewId()))
-                    .willReturn(Optional.empty());
+	@Nested
+	@DisplayName("크루 상세 조회 시,")
+	class View {
+		@Test
+		@DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
+		void throwNotFoundCrewException_whenCrewNotFound() {
+			CrewCommand.Detail command = new CrewCommand.Detail(1L, 2L);
+			given(crewRepository.findById(command.crewId()))
+				.willReturn(Optional.empty());
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrew(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrew(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
-        }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
+		}
 
-        @Test
-        @DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
-        void throwNotCrewMemberException_whenUserNotInCrew() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("abc123"));
-            given(crewRepository.findById(crew.getId()))
-                    .willReturn(Optional.of(crew));
-            CrewCommand.Detail command = new CrewCommand.Detail(crew.getId(), 3L);
+		@Test
+		@DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
+		void throwNotCrewMemberException_whenUserNotInCrew() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("abc123"));
+			given(crewRepository.findById(crew.getId()))
+				.willReturn(Optional.of(crew));
+			CrewCommand.Detail command = new CrewCommand.Detail(crew.getId(), 3L);
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrew(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrew(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
-    }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
+	}
 
-    @Nested
-    @DisplayName("크루원 목록 조회 시,")
-    class GetMembers {
+	@Nested
+	@DisplayName("크루원 목록 조회 시,")
+	class GetMembers {
 
-        @Test
-        @DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
-        void throwNotFoundCrewException_whenCrewNotFound() {
-            CrewCommand.Members command = new CrewCommand.Members(1L, 2L);
-            given(crewRepository.findById(command.crewId()))
-                    .willReturn(Optional.empty());
+		@Test
+		@DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
+		void throwNotFoundCrewException_whenCrewNotFound() {
+			CrewCommand.Members command = new CrewCommand.Members(1L, 2L);
+			given(crewRepository.findById(command.crewId()))
+				.willReturn(Optional.empty());
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrewMembers(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrewMembers(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
-        }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
+		}
 
-        @Test
-        @DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
-        void throwNotCrewMemberException_whenUserNotInCrew() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("xyz789"));
-            given(crewRepository.findById(crew.getId()))
-                    .willReturn(Optional.of(crew));
-            CrewCommand.Members command = new CrewCommand.Members(crew.getId(), 3L);
+		@Test
+		@DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
+		void throwNotCrewMemberException_whenUserNotInCrew() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("xyz789"));
+			given(crewRepository.findById(crew.getId()))
+				.willReturn(Optional.of(crew));
+			CrewCommand.Members command = new CrewCommand.Members(crew.getId(), 3L);
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrewMembers(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.getCrewMembers(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
 
-        @Test
-        @DisplayName("현재 크루에 활동중인 멤버만 조회된다.")
-        void getActiveMembers() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Active Crew"), new Code("abc123"));
-            crew.joinMember(2L);
-            crew.joinMember(3L);
-            crew.leaveMember(3L);
-            given(crewRepository.findById(crew.getId()))
-                    .willReturn(Optional.of(crew));
-            CrewCommand.Members command = new CrewCommand.Members(crew.getId(), 1L);
+		@Test
+		@DisplayName("현재 크루에 활동중인 멤버만 조회된다.")
+		void getActiveMembers() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Active Crew"), new Code("abc123"));
+			crew.joinMember(2L);
+			crew.joinMember(3L);
+			crew.leaveMember(3L);
+			given(crewRepository.findById(crew.getId()))
+				.willReturn(Optional.of(crew));
+			CrewCommand.Members command = new CrewCommand.Members(crew.getId(), 1L);
 
-            List<CrewMember> members = crewService.getCrewMembers(command);
+			List<CrewMember> members = crewService.getCrewMembers(command);
 
-            assertThat(members).hasSize(2);
-            assertThat(members)
-                    .extracting("memberId")
-                    .containsExactlyInAnyOrder(1L, 2L);
-        }
-    }
+			assertThat(members).hasSize(2);
+			assertThat(members)
+				.extracting("memberId")
+				.containsExactlyInAnyOrder(1L, 2L);
+		}
+	}
 
-    @Nested
-    @DisplayName("크루원 탈퇴 시,")
-    class Leave {
+	@Nested
+	@DisplayName("크루원 탈퇴 시,")
+	class Leave {
 
-        @Test
-        @DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
-        void throwNotFoundCrewException_whenCrewNotFound() {
-            CrewCommand.Leave command = new CrewCommand.Leave(1L, 2L, null);
-            given(crewRepository.findById(command.crewId()))
-                    .willReturn(Optional.empty());
+		@Test
+		@DisplayName("크루가 존재하지 않으면 NOT_FOUND_CREW 예외를 발생시킨다.")
+		void throwNotFoundCrewException_whenCrewNotFound() {
+			CrewCommand.Leave command = new CrewCommand.Leave(1L, 2L, null);
+			given(crewRepository.findById(command.crewId()))
+				.willReturn(Optional.empty());
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
-        }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_FOUND_CREW));
+		}
 
-        @Test
-        @DisplayName("리더가 탈퇴할 경우 새로운 리더를 지정하지 않으면, HAVE_TO_DELEGATE_LEADER 예외를 발생시킨다.")
-        void throwHaveToDelegateLeaderException_whenLeaderLeavesWithoutDelegation() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("def456"));
-            crew.joinMember(2L);
-            given(crewRepository.findById(crew.getId()))
-                    .willReturn(Optional.of(crew));
-            CrewCommand.Leave command = new CrewCommand.Leave(crew.getId(), 1L, null);
+		@Test
+		@DisplayName("리더가 탈퇴할 경우 새로운 리더를 지정하지 않으면, HAVE_TO_DELEGATE_LEADER 예외를 발생시킨다.")
+		void throwHaveToDelegateLeaderException_whenLeaderLeavesWithoutDelegation() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("def456"));
+			crew.joinMember(2L);
+			given(crewRepository.findById(crew.getId()))
+				.willReturn(Optional.of(crew));
+			CrewCommand.Leave command = new CrewCommand.Leave(crew.getId(), 1L, null);
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.HAVE_TO_DELEGATE_LEADER));
-        }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.HAVE_TO_DELEGATE_LEADER));
+		}
 
-        @Test
-        @DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
-        void throwNotCrewMemberException_whenUserNotInCrew() {
-            Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("xyz789"));
-            crew.joinMember(3L);
-            crew.leaveMember(3L);
-            given(crewRepository.findById(crew.getId()))
-                    .willReturn(Optional.of(crew));
-            CrewCommand.Leave command = new CrewCommand.Leave(crew.getId(), 3L, null);
+		@Test
+		@DisplayName("사용자가 크루 멤버가 아니면 NOT_CREW_MEMBER 예외를 발생시킨다.")
+		void throwNotCrewMemberException_whenUserNotInCrew() {
+			Crew crew = Crew.of(new CrewCommand.Create(1L, "Test Crew"), new Code("xyz789"));
+			crew.joinMember(3L);
+			crew.leaveMember(3L);
+			given(crewRepository.findById(crew.getId()))
+				.willReturn(Optional.of(crew));
+			CrewCommand.Leave command = new CrewCommand.Leave(crew.getId(), 3L, null);
 
-            GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
+			GlobalException thrown = assertThrows(GlobalException.class, () -> crewService.leave(command));
 
-            assertThat(thrown)
-                    .usingRecursiveComparison()
-                    .isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
-        }
-    }
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(CrewErrorCode.NOT_CREW_MEMBER));
+		}
+	}
 }

--- a/src/test/java/com/runky/notification/domain/push/DeviceTokenServiceTest.java
+++ b/src/test/java/com/runky/notification/domain/push/DeviceTokenServiceTest.java
@@ -1,0 +1,171 @@
+package com.runky.notification.domain.push;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import com.runky.global.error.GlobalException;
+import com.runky.notification.error.NotificationErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings
+class DeviceTokenServiceTest {
+
+	@Mock
+	DeviceTokenRepository deviceTokenRepository;
+
+	@InjectMocks
+	DeviceTokenService deviceTokenService;
+
+	@Nested
+	@DisplayName("register()")
+	class Register {
+		@Test
+		@DisplayName("정상 등록 시 Repository.save 가 호출된다.")
+		void saveOnce() {
+			// given
+			when(deviceTokenRepository.save(any(DeviceToken.class)))
+				.thenAnswer(inv -> inv.getArgument(0));
+
+			// when
+			deviceTokenService.register(new DeviceTokenCommand.Register(1L, "tkn-123"));
+
+			// then
+			verify(deviceTokenRepository)
+				.save(argThat(dt -> dt.getMemberId().equals(1L)
+					&& dt.getToken().equals("tkn-123")
+					&& dt.isActive()));
+		}
+
+		@Test
+		@DisplayName("토큰 유니크 키 충돌 시, GlobalException(DUPLICATE_UNIQUE_KEY_DEVICE_TOKEN)을 던진다.")
+		void duplicateTokenToGlobalException() {
+			// given: 서비스는 제약조건명 'ux_device_token_token' 포함 메시지를 매핑 기준으로 사용
+			when(deviceTokenRepository.save(any(DeviceToken.class)))
+				.thenThrow(new DataIntegrityViolationException("... ux_device_token_token ..."));
+
+			// when
+			GlobalException thrown = assertThrows(GlobalException.class,
+				() -> deviceTokenService.register(new DeviceTokenCommand.Register(1L, "dup-token")));
+
+			// then
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(NotificationErrorCode.DUPLICATE_UNIQUE_KEY_DEVICE_TOKEN));
+		}
+	}
+
+	@Nested
+	@DisplayName("delete()")
+	class Delete {
+		@Test
+		@DisplayName("삭제 대상이 있으면 삭제 개수를 반환한다.")
+		void deleteExisting() {
+			// given
+			when(deviceTokenRepository.deleteByMemberIdAndToken(1L, "tkn-123")).thenReturn(1);
+
+			// when
+			DeviceTokenInfo.Delete result =
+				deviceTokenService.delete(new DeviceTokenCommand.Delete(1L, "tkn-123"));
+
+			// then
+			assertThat(result.count()).isEqualTo(1);
+		}
+
+		@Test
+		@DisplayName("삭제 대상이 없으면 GlobalException(NOT_EXIST_TO_DELETE_DEVICE_TOKEN)을 던진다.")
+		void deleteNotFound() {
+			// given
+			when(deviceTokenRepository.deleteByMemberIdAndToken(1L, "nope")).thenReturn(0);
+
+			// when
+			GlobalException thrown = assertThrows(GlobalException.class,
+				() -> deviceTokenService.delete(new DeviceTokenCommand.Delete(1L, "nope")));
+
+			// then
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(NotificationErrorCode.NOT_EXIST_TO_DELETE_DEVICE_TOKEN));
+		}
+	}
+
+	@Nested
+	@DisplayName("view()")
+	class View {
+		@Test
+		@DisplayName("memberId+token으로 조회에 성공하면 View DTO를 반환한다.")
+		void viewFound() {
+			// given
+			DeviceToken entity = DeviceToken.builder()
+				.id(10L).memberId(1L).token("tkn-123").active(true).build();
+
+			when(deviceTokenRepository.findByMemberIdAndToken(1L, "tkn-123"))
+				.thenReturn(Optional.of(entity));
+
+			// when
+			DeviceTokenInfo.View view =
+				deviceTokenService.view(new DeviceTokenCommand.Find(1L, "tkn-123"));
+
+			// then
+			assertThat(view.id()).isEqualTo(10L);
+			assertThat(view.memberId()).isEqualTo(1L);
+			assertThat(view.token()).isEqualTo("tkn-123");
+			assertThat(view.active()).isTrue();
+		}
+
+		@Test
+		@DisplayName("조회 대상이 없으면 GlobalException(NOT_FOUND_DEVICE_TOKEN)을 던진다.")
+		void viewNotFound() {
+			when(deviceTokenRepository.findByMemberIdAndToken(1L, "nope"))
+				.thenReturn(Optional.empty());
+
+			GlobalException thrown = assertThrows(GlobalException.class,
+				() -> deviceTokenService.view(new DeviceTokenCommand.Find(1L, "nope")));
+
+			assertThat(thrown)
+				.usingRecursiveComparison()
+				.isEqualTo(new GlobalException(NotificationErrorCode.NOT_FOUND_DEVICE_TOKEN));
+		}
+	}
+
+	@Nested
+	@DisplayName("isExists()")
+	class IsExists {
+		@Test
+		@DisplayName("활성 토큰 존재 여부를 반환한다(존재)")
+		void existsTrue() {
+			when(deviceTokenRepository.existsActiveByMemberIdAndToken(1L, "tkn-123"))
+				.thenReturn(true);
+
+			DeviceTokenInfo.Existence existence =
+				deviceTokenService.isExists(new DeviceTokenCommand.Find(1L, "tkn-123"));
+
+			assertThat(existence.exists()).isTrue();
+		}
+
+		@Test
+		@DisplayName("활성 토큰 존재 여부를 반환한다(부재)")
+		void existsFalse() {
+			when(deviceTokenRepository.existsActiveByMemberIdAndToken(1L, "tkn-123"))
+				.thenReturn(false);
+
+			DeviceTokenInfo.Existence existence =
+				deviceTokenService.isExists(new DeviceTokenCommand.Find(1L, "tkn-123"));
+
+			assertThat(existence.exists()).isFalse();
+		}
+	}
+}

--- a/src/test/java/com/runky/notification/domain/push/DeviceTokenTest.java
+++ b/src/test/java/com/runky/notification/domain/push/DeviceTokenTest.java
@@ -1,0 +1,52 @@
+package com.runky.notification.domain.push;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DeviceTokenTest {
+
+	@Nested
+	@DisplayName("DeviceToken.register()")
+	class Register {
+		@Test
+		@DisplayName("memberId, token으로 active=true 상태의 토큰을 생성한다.")
+		void createActiveToken() {
+			// when
+			DeviceToken token = DeviceToken.register(1L, "tkn-123");
+
+			// then
+			assertThat(token.getId()).isNull(); // 영속 전이므로 null
+			assertThat(token.getMemberId()).isEqualTo(1L);
+			assertThat(token.getToken()).isEqualTo("tkn-123");
+			assertThat(token.isActive()).isTrue();
+		}
+	}
+
+	@Nested
+	@DisplayName("활성/비활성 전환")
+	class Toggle {
+		@Test
+		@DisplayName("deactivate() 호출 시 active=false 가 된다.")
+		void deactivate() {
+			DeviceToken token = DeviceToken.register(1L, "tkn-123");
+
+			token.deactivate();
+
+			assertThat(token.isActive()).isFalse();
+		}
+
+		@Test
+		@DisplayName("reactivate() 호출 시 active=true 가 된다.")
+		void reactivate() {
+			DeviceToken token = DeviceToken.register(1L, "tkn-123");
+			token.deactivate();
+
+			token.reactivate();
+
+			assertThat(token.isActive()).isTrue();
+		}
+	}
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #45

## 📌 작업 내용 및 특이사항
- FCM을 위한 디바이스 토큰 서버 저장,삭제 API 구현
- 디바이스 토큰 조회 기능(서비스) 구현

## 📝 참고사항
- 다음 기능으로 디바이스 토큰을 활용해서 NotificationFacade 기능(알림 발송)을 만들예정

### DeviceToken Entity
- memberId & token 복합인덱스 존재
- token은 유니크함.

-  `지금의 디바이스 토큰은 최소화 기능(발급기능,조회기능)에 초점을 둔 최소 기능의 Entity입니다.`
- MVP 이후의 디바이스 토큰의 엔티티는 다음과 같이 리팩토링할 것 같습니다.
```java
    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column(name = "member_id", nullable = false)
    private Long memberId;

    @Column(name = "installation_id", nullable = false, length = 128)
    private String installationId; // FIS FID 등

    @Column(name = "platform", nullable = false, length = 16) // ANDROID/IOS/WEB
    private String platform;

    @Column(name = "token", nullable = false, length = 512)
    private String token;

    @Column(name = "app_version", length = 32)
    private String appVersion;

    @Column(name = "active", nullable = false)
    private boolean active;
```
왜 이런 데이터들이 필요한지 GPT에게 물어봤습니다. 

> GPT야. 왜 token값 말고도 다른 정보들이 필요한지 알려줄래?

Register(String token, String installationId, String platform, String appVersion)에서 installationId / platform / appVersion을 받는 이유는 “토큰만으로는 해결되지 않는 운영·정합·확장” 문제들을 안정적으로 다루기 위함입니다. 각각을 실전 시나리오와 함께 설명하겠습니다.

운영 안정성과 확장성이 뛰어난 푸시 알림 시스템을 구축하기 위해서는, 단순히 푸시 토큰 외에 installationId (앱 설치 식별자), platform (플랫폼), appVersion (앱 버전)을 등록 DTO에 포함하는 것이 필수적입니다. 이 세 가지 정보는 각기 다른 핵심적인 역할을 수행하며 시스템의 여러 문제를 근본적으로 해결합니다.

installationId는 수시로 변경될 수 있는 토큰과 달리, 특정 앱 설치를 지속적으로 식별하는 고유 키 역할을 합니다. 사용자가 앱을 재설치하거나 FCM 토큰이 자동으로 갱신될 때, installationId가 없다면 매번 새로운 데이터가 쌓여 중복 레코드가 폭증하게 됩니다. 하지만 이 식별자를 기준으로 기존 레코드의 토큰만 교체(Upsert)함으로써 데이터 중복을 막고, 한 명의 사용자에게 중복된 알림이 발송되는 것을 방지할 수 있습니다. 또한, 한 기기에서 다른 계정으로 로그인할 때 installationId를 통해 기기를 새 사용자에게 정확히 재귀속하고 이전 사용자와의 연결을 끊어, 이전 사용자에게 알림이 잘못 전송되는 심각한 오류를 막아줍니다.

platform과 appVersion은 다양한 클라이언트 환경에 맞춰 안정적으로 메시지를 전송하고 관리하기 위한 기반이 됩니다. platform 정보는 Android의 channelId나 iOS의 badge처럼 각 운영체제에 맞는 고유한 전송 옵션과 페이로드 형식을 적용하는 데 필수적입니다. 이 정보가 없으면 모든 플랫폼에 동일한 메시지를 보내 불필요한 전송 실패를 유발하고, 플랫폼별 캠페인이나 디버깅이 불가능해집니다. appVersion 정보는 호환성 관리에 핵심적인 역할을 합니다. 새로운 기능이 담긴 알림을 해당 기능이 구현된 앱 버전에만 조건부로 발송하여 하위 버전에서의 오류를 방지하고, 특정 버전의 버그에 대응하거나 점진적인 기능 배포(A/B 테스트)를 수행하는 등 정교한 운영 전략을 가능하게 합니다.

결론적으로, 이 세 가지 필드는 서버가 디바이스 토큰을 등록하고 갱신하는 핵심 로직의 근간이 됩니다. 신규 토큰 요청 시, 서버는 토큰을 먼저 조회하고, 정보가 없다면 installationId를 기준으로 다시 조회하여 토큰만 교체합니다. 이 두 가지 경우에 모두 해당하지 않을 때만 새로운 기기로 인식하여 데이터를 생성합니다. 이처럼 installationId는 데이터의 정합성과 사용자 식별의 핵심이며, platform과 appVersion은 전송의 정확성과 서비스 호환성을 보장합니다. 따라서 이들을 등록 DTO에 포함하는 것은 선택이 아닌, 안정적이고 확장 가능한 알림 시스템을 위한 필수 설계입니다.
## 📚 기타
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device token management for push notifications.
  * POST /api/device-tokens to register a device token (requires X-USER-ID header).
  * DELETE /api/device-tokens to remove a device token, returning the number deleted.
* **Documentation**
  * OpenAPI/Swagger docs added for the new endpoints, including request/response models and error responses (404 when token not found, 409 on duplicates).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->