### PR TITLE
Feat: 멤버의 런닝 상태 조회 서비스 기능 추가

### DIFF
--- a/src/main/java/com/runky/running/api/RunningApiSpec.java
+++ b/src/main/java/com/runky/running/api/RunningApiSpec.java
@@ -22,5 +22,13 @@ public interface RunningApiSpec {
 		@Schema(description = "종료할 런닝 ID") Long runningId,
 		@Schema(description = "런닝 요약 및 트랙 정보") RunningRequest.End request
 	);
+
+	@Operation(
+		summary = "오늘 달린 기록 요약 조회",
+		description = "요청자 기준 KST(UTC+9) ‘오늘’에 **완료된** 모든 런닝 기록을 합산하여 요약을 반환합니다."
+	)
+	ApiResponse<RunningResponse.TodaySummary> getToday(
+		@Parameter(hidden = true) MemberPrincipal requester
+	);
 }
 

--- a/src/main/java/com/runky/running/api/RunningController.java
+++ b/src/main/java/com/runky/running/api/RunningController.java
@@ -1,6 +1,10 @@
 package com.runky.running.api;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/runnings")
 @RequiredArgsConstructor
 public class RunningController implements RunningApiSpec {
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
 	private final RunningFacade runningFacade;
 
@@ -45,5 +50,14 @@ public class RunningController implements RunningApiSpec {
 
 		RunningResponse.End response = RunningResponse.End.from(result);
 		return ApiResponse.success(response);
+	}
+
+	@GetMapping("/today")
+	public ApiResponse<RunningResponse.TodaySummary> getToday(
+		@AuthenticationPrincipal MemberPrincipal requester
+	) {
+		var result = runningFacade.getTodaySummary(new RunningCriteria.TodaySummary(requester.memberId(),
+			LocalDateTime.now().atZone(KST).toLocalDateTime()));
+		return ApiResponse.success(RunningResponse.TodaySummary.from(result));
 	}
 }

--- a/src/main/java/com/runky/running/api/RunningResponse.java
+++ b/src/main/java/com/runky/running/api/RunningResponse.java
@@ -20,4 +20,10 @@ public sealed interface RunningResponse {
 				result.endedAt());
 		}
 	}
+
+	record TodaySummary(Double totalDistanceMeter, Long durationSeconds, Double avgSpeedMps) {
+		public static TodaySummary from(RunningResult.TodaySummary r) {
+			return new RunningResponse.TodaySummary(r.totalDistanceMeters(), r.durationSeconds(), r.avgSpeedMps());
+		}
+	}
 }

--- a/src/main/java/com/runky/running/application/RunningCriteria.java
+++ b/src/main/java/com/runky/running/application/RunningCriteria.java
@@ -1,5 +1,7 @@
 package com.runky.running.application;
 
+import java.time.LocalDateTime;
+
 import com.runky.running.domain.RunningCommand;
 
 public sealed interface RunningCriteria {
@@ -28,5 +30,8 @@ public sealed interface RunningCriteria {
 				runningId, runnerId, totalDistanceMinutes, durationSeconds, avgSpeedMPS, format, points, pointCount
 			);
 		}
+	}
+
+	record TodaySummary(Long runnerId, LocalDateTime now) implements RunningCriteria {
 	}
 }

--- a/src/main/java/com/runky/running/application/RunningFacade.java
+++ b/src/main/java/com/runky/running/application/RunningFacade.java
@@ -1,5 +1,6 @@
 package com.runky.running.application;
 
+import java.time.ZoneId;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class RunningFacade {
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 	private final RunningService runningService;
 	private final PushService pushService;
 	private final MemberService memberService;
@@ -47,6 +49,12 @@ public class RunningFacade {
 	public RunningResult.End end(RunningCriteria.End criteria) {
 		RunningInfo.End info = runningService.end(criteria.toCommand());
 		return RunningResult.End.from(info);
+	}
+
+	@Transactional(readOnly = true)
+	public RunningResult.TodaySummary getTodaySummary(RunningCriteria.TodaySummary criteria) {
+
+		return RunningResult.TodaySummary.from(runningService.getTodaySummary(criteria.runnerId(), criteria.now()));
 	}
 
 }

--- a/src/main/java/com/runky/running/application/RunningResult.java
+++ b/src/main/java/com/runky/running/application/RunningResult.java
@@ -31,4 +31,10 @@ public sealed interface RunningResult {
 		}
 	}
 
+	record TodaySummary(Double totalDistanceMeters, Long durationSeconds, Double avgSpeedMps) {
+		public static TodaySummary from(RunningInfo.TodaySummary info) {
+			return new TodaySummary(info.totalDistanceMeters(), info.durationSeconds(), info.avgSpeedMps());
+		}
+
+	}
 }

--- a/src/main/java/com/runky/running/domain/RunningInfo.java
+++ b/src/main/java/com/runky/running/domain/RunningInfo.java
@@ -27,4 +27,7 @@ public sealed interface RunningInfo {
 
 	record RunnerStatus(Long runnerId, boolean isRunning) implements RunningInfo {
 	}
+
+	record TodaySummary(Double totalDistanceMeters, Long durationSeconds, Double avgSpeedMps) {
+	}
 }

--- a/src/main/java/com/runky/running/domain/RunningInfo.java
+++ b/src/main/java/com/runky/running/domain/RunningInfo.java
@@ -19,9 +19,12 @@ public sealed interface RunningInfo {
 		implements RunningInfo {
 	}
 
-    record TotalDistance(Long runnerId, Double totalDistance) implements RunningInfo {
-    }
+	record TotalDistance(Long runnerId, Double totalDistance) implements RunningInfo {
+	}
 
-    record RunningResult(Long runnerId, Double distance) implements RunningInfo {
-    }
+	record RunningResult(Long runnerId, Double distance) implements RunningInfo {
+	}
+
+	record RunnerStatus(Long runnerId, boolean isRunning) implements RunningInfo {
+	}
 }

--- a/src/main/java/com/runky/running/domain/RunningRepository.java
+++ b/src/main/java/com/runky/running/domain/RunningRepository.java
@@ -24,5 +24,7 @@ public interface RunningRepository {
 	boolean existsByRunnerIdAndStatusAndEndedAtIsNull(Long memberId, Running.Status status);
 
 	Set<Long> findRunnerIdsByStatusAndEndedAtIsNull(final Collection<Long> runnerIds, final Running.Status status);
-	
+
+	List<Running> findFinishedOnDate(Long runnerId, LocalDateTime now);
+
 }

--- a/src/main/java/com/runky/running/domain/RunningRepository.java
+++ b/src/main/java/com/runky/running/domain/RunningRepository.java
@@ -1,21 +1,28 @@
 package com.runky.running.domain;
 
-import com.runky.running.domain.RunningInfo.RunningResult;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+
+import com.runky.running.domain.RunningInfo.RunningResult;
 
 public interface RunningRepository {
-    boolean existsByRunnerIdAndEndedAtIsNull(Long runnerId);
-  
-    boolean existsByIdAndStatus(Long id, Running.Status status);
+	boolean existsByRunnerIdAndEndedAtIsNull(Long runnerId);
 
-    Optional<Running> findByIdAndRunnerId(Long id, Long runnerId);
+	boolean existsByIdAndStatus(Long id, Running.Status status);
 
-    Running save(Running running);
+	Optional<Running> findByIdAndRunnerId(Long id, Long runnerId);
 
-    List<RunningResult> findTotalDistancesPeriod(LocalDateTime from, LocalDateTime to);
-  
-	  Optional<Long> findRunnerIdById(Long id);
+	Running save(Running running);
 
+	List<RunningResult> findTotalDistancesPeriod(LocalDateTime from, LocalDateTime to);
+
+	Optional<Long> findRunnerIdById(Long id);
+
+	boolean existsByRunnerIdAndStatusAndEndedAtIsNull(Long memberId, Running.Status status);
+
+	Set<Long> findRunnerIdsByStatusAndEndedAtIsNull(final Collection<Long> runnerIds, final Running.Status status);
+	
 }

--- a/src/main/java/com/runky/running/domain/RunningService.java
+++ b/src/main/java/com/runky/running/domain/RunningService.java
@@ -2,6 +2,7 @@ package com.runky.running.domain;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,5 +72,23 @@ public class RunningService {
 	public Long getRunnerId(final Long runningId) {
 		return runningRepository.findRunnerIdById(runningId)
 			.orElseThrow(() -> new GlobalException(RunningErrorCode.NOT_FOUND_RUNNING));
+	}
+
+	@Transactional(readOnly = true)
+	public boolean getRunnerStatus(final Long runnerId) {
+		return runningRepository.existsByRunnerIdAndStatusAndEndedAtIsNull(runnerId, Running.Status.RUNNING);
+	}
+
+	@Transactional(readOnly = true)
+	public List<RunningInfo.RunnerStatus> getRunnerStatuses(List<Long> runnerIds) {
+
+		List<Long> distinctIds = runnerIds.stream().distinct().toList();
+
+		Set<Long> activeIds = runningRepository
+			.findRunnerIdsByStatusAndEndedAtIsNull(distinctIds, Running.Status.RUNNING);
+
+		return distinctIds.stream()
+			.map(id -> new RunningInfo.RunnerStatus(id, activeIds.contains(id)))
+			.toList();
 	}
 }

--- a/src/main/java/com/runky/running/domain/RunningService.java
+++ b/src/main/java/com/runky/running/domain/RunningService.java
@@ -1,11 +1,8 @@
 package com.runky.running.domain;
 
-import com.runky.running.domain.RunningInfo;
 import java.time.LocalDateTime;
-
-
 import java.util.List;
-import org.springframework.context.ApplicationEventPublisher;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,7 +37,7 @@ public class RunningService {
 			throw new GlobalException(RunningErrorCode.NOT_ACTIVE_RUNNING);
 		}
 
-        LocalDateTime now = LocalDateTime.now();
+		LocalDateTime now = LocalDateTime.now();
 		running.finish(command.totalDistanceMinutes(), command.durationSeconds(), command.avgSpeedMPS(), now);
 		runningRepository.save(running);
 
@@ -60,15 +57,17 @@ public class RunningService {
 			running.getStartedAt(), running.getEndedAt());
 	}
 
-    @Transactional(readOnly = true)
-    public List<RunningInfo.RunningResult> getTotalDistancesPeriod(LocalDateTime from, LocalDateTime to) {
-        return runningRepository.findTotalDistancesPeriod(from, to);
-    }
+	@Transactional(readOnly = true)
+	public List<RunningInfo.RunningResult> getTotalDistancesPeriod(LocalDateTime from, LocalDateTime to) {
+		return runningRepository.findTotalDistancesPeriod(from, to);
+	}
 
+	@Transactional(readOnly = true)
 	public boolean isActive(final Long runningId) {
 		return runningRepository.existsByIdAndStatus(runningId, Running.Status.RUNNING);
 	}
 
+	@Transactional(readOnly = true)
 	public Long getRunnerId(final Long runningId) {
 		return runningRepository.findRunnerIdById(runningId)
 			.orElseThrow(() -> new GlobalException(RunningErrorCode.NOT_FOUND_RUNNING));

--- a/src/main/java/com/runky/running/infra/RunningJpaRepository.java
+++ b/src/main/java/com/runky/running/infra/RunningJpaRepository.java
@@ -1,8 +1,10 @@
 package com.runky.running.infra;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -31,4 +33,14 @@ public interface RunningJpaRepository extends JpaRepository<Running, Long> {
 	@Query("select r.runnerId from Running r where r.id = :id")
 	Optional<Long> findRunnerIdById(Long id);
 
+	boolean existsByRunnerIdAndStatusAndEndedAtIsNull(Long runnerId, Running.Status status);
+
+	@Query("""
+		select distinct r.runnerId
+		  from Running r
+		 where r.status = :status
+		   and r.endedAt is null
+		   and r.runnerId in :runnerIds
+		""")
+	Set<Long> findRunnerIdsByStatusAndEndedAtIsNull(Collection<Long> runnerIds, Running.Status status);
 }

--- a/src/main/java/com/runky/running/infra/RunningJpaRepository.java
+++ b/src/main/java/com/runky/running/infra/RunningJpaRepository.java
@@ -43,4 +43,14 @@ public interface RunningJpaRepository extends JpaRepository<Running, Long> {
 		   and r.runnerId in :runnerIds
 		""")
 	Set<Long> findRunnerIdsByStatusAndEndedAtIsNull(Collection<Long> runnerIds, Running.Status status);
+
+	@Query("""
+			select r
+			  from Running r
+			 where r.runnerId = :runnerId
+			   and r.status = com.runky.running.domain.Running$Status.FINISHED
+			   and r.endedAt >= :from and r.endedAt < :to
+			 order by r.endedAt desc
+		""")
+	List<Running> findFinishedByEndedAtBetween(Long runnerId, LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/runky/running/infra/RunningRepositoryImpl.java
+++ b/src/main/java/com/runky/running/infra/RunningRepositoryImpl.java
@@ -1,40 +1,45 @@
 package com.runky.running.infra;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.stereotype.Repository;
+
 import com.runky.running.domain.Running;
 import com.runky.running.domain.RunningInfo;
 import com.runky.running.domain.RunningRepository;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class RunningRepositoryImpl implements RunningRepository {
 
-    private final RunningJpaRepository jpaRepository;
+	private final RunningJpaRepository jpaRepository;
 
-    @Override
-    public boolean existsByRunnerIdAndEndedAtIsNull(final Long runnerId) {
-        return jpaRepository.existsByRunnerIdAndEndedAtIsNull(runnerId);
-    }
+	@Override
+	public boolean existsByRunnerIdAndEndedAtIsNull(final Long runnerId) {
+		return jpaRepository.existsByRunnerIdAndEndedAtIsNull(runnerId);
+	}
 
-    @Override
-    public Optional<Running> findByIdAndRunnerId(final Long id, final Long runnerId) {
-        return jpaRepository.findByIdAndRunnerId(id, runnerId);
-    }
+	@Override
+	public Optional<Running> findByIdAndRunnerId(final Long id, final Long runnerId) {
+		return jpaRepository.findByIdAndRunnerId(id, runnerId);
+	}
 
-    @Override
-    public Running save(final Running running) {
-        jpaRepository.save(running);
-        return running;
-    }
+	@Override
+	public Running save(final Running running) {
+		jpaRepository.save(running);
+		return running;
+	}
 
-    @Override
-    public List<RunningInfo.RunningResult> findTotalDistancesPeriod(LocalDateTime from, LocalDateTime to) {
-        return jpaRepository.findRunnerDistanceResultsByPeriod(from, to);
-    }
+	@Override
+	public List<RunningInfo.RunningResult> findTotalDistancesPeriod(LocalDateTime from, LocalDateTime to) {
+		return jpaRepository.findRunnerDistanceResultsByPeriod(from, to);
+	}
 
 	@Override
 	public boolean existsByIdAndStatus(final Long id, final Running.Status status) {
@@ -44,5 +49,16 @@ public class RunningRepositoryImpl implements RunningRepository {
 	@Override
 	public Optional<Long> findRunnerIdById(final Long id) {
 		return jpaRepository.findRunnerIdById(id);
+	}
+
+	@Override
+	public boolean existsByRunnerIdAndStatusAndEndedAtIsNull(final Long memberId, final Running.Status status) {
+		return jpaRepository.existsByRunnerIdAndStatusAndEndedAtIsNull(memberId, status);
+	}
+
+	@Override
+	public Set<Long> findRunnerIdsByStatusAndEndedAtIsNull(final Collection<Long> runnerIds,
+		final Running.Status status) {
+		return jpaRepository.findRunnerIdsByStatusAndEndedAtIsNull(runnerIds, status);
 	}
 }

--- a/src/main/java/com/runky/running/infra/RunningRepositoryImpl.java
+++ b/src/main/java/com/runky/running/infra/RunningRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.runky.running.infra;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -61,4 +62,13 @@ public class RunningRepositoryImpl implements RunningRepository {
 		final Running.Status status) {
 		return jpaRepository.findRunnerIdsByStatusAndEndedAtIsNull(runnerIds, status);
 	}
+
+	@Override
+	public List<Running> findFinishedOnDate(final Long runnerId, final LocalDateTime now) {
+		LocalDate day = now.toLocalDate();
+		LocalDateTime from = day.atStartOfDay();
+		LocalDateTime to = day.plusDays(1).atStartOfDay();
+		return jpaRepository.findFinishedByEndedAtBetween(runnerId, from, to);
+	}
+
 }

--- a/src/test/java/com/runky/running/domain/RunningServiceTest.java
+++ b/src/test/java/com/runky/running/domain/RunningServiceTest.java
@@ -1,0 +1,81 @@
+package com.runky.running.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.runky.running.infra.RunningJpaRepository;
+import com.runky.utils.DatabaseCleanUp;
+
+@SpringBootTest
+class RunningServiceTest {
+	@Autowired
+	RunningService runningService;
+	@Autowired
+	RunningJpaRepository runningJpaRepository;
+	@Autowired
+	private DatabaseCleanUp databaseCleanUp;
+
+	@AfterEach
+	void tearDown() {
+		databaseCleanUp.truncateAllTables();
+	}
+
+	@DisplayName("멤버의 런닝 상태를 멤버Id로 조회할 수 있다.")
+	@Test
+	void existsByRunnerIdAndStatus_works() {
+		var now = LocalDateTime.now();
+		var running = Running.start(1L, now);
+		runningJpaRepository.save(running);
+
+		assertThat(runningJpaRepository.existsByRunnerIdAndStatusAndEndedAtIsNull(1L, Running.Status.RUNNING)).isTrue();
+		assertThat(
+			runningJpaRepository.existsByRunnerIdAndStatusAndEndedAtIsNull(1L, Running.Status.FINISHED)).isFalse();
+	}
+
+	@DisplayName("여러 멤버의 런닝 상태를 일괄 조회하면 (runnerId, isRunning)으로 반환한다 - 중복 runnerId는 제거")
+	@Test
+	void getRunnerStatuses_bulk_ok() {
+		// given
+		var now = LocalDateTime.now();
+
+		// 10L: 활성 RUNNING (endedAt = null)
+		var active = Running.start(10L, now);
+		runningJpaRepository.save(active);
+
+		// 20L: FINISHED (endedAt != null)
+		var finished = Running.start(20L, now.minusMinutes(30));
+		runningJpaRepository.save(finished);
+		finished.finish(5000d, 1800L, 2.7, now.minusMinutes(10));
+		runningJpaRepository.save(finished);
+
+		// 30L: 어떤 러닝도 없음 → 비활성
+
+		// when
+		var result = runningService.getRunnerStatuses(List.of(10L, 20L, 20L, 30L));
+
+		// then
+		// distinct()를 적용하므로 10,20,30 총 3개
+		assertThat(result).hasSize(3);
+
+		// (runnerId → isRunning) 맵으로 검증
+		Map<Long, Boolean> statusMap = result.stream()
+			.collect(Collectors.toMap(
+				RunningInfo.RunnerStatus::runnerId,
+				RunningInfo.RunnerStatus::isRunning
+			));
+
+		assertThat(statusMap.get(10L)).isTrue();   // RUNNING & endedAt IS NULL
+		assertThat(statusMap.get(20L)).isFalse();  // FINISHED
+		assertThat(statusMap.get(30L)).isFalse();  // 기록 없음
+	}
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #86

## 📌 작업 내용 및 특이사항
- 1명 멤버상태 조회 서비스 메서드 
- N명 멤버상태 조회 서비스 메서드

## 📝 참고사항
<img width="782" height="401" alt="image" src="https://github.com/user-attachments/assets/16efe21a-c67a-4f57-a8e3-e7c6604ece50" />


## 📚 기타
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Check if a runner is currently active.
  - Retrieve running statuses for multiple runners at once (input de-duplication).
  - Get a "Today" running summary (total distance, duration, avg speed) for the authenticated user.

- Enhancements
  - More efficient status queries for large sets of runner IDs.
  - Read-only transactions applied to relevant read operations.
  - Date-bound finished-run queries for accurate daily summaries.

- Tests
  - Added integration tests for active-status checks, bulk status retrieval, and today/period summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->