### PR TITLE
refactor(Security.config): CORS 오리진 설정

### DIFF
--- a/src/main/java/com/runky/global/security/SecurityConfig.java
+++ b/src/main/java/com/runky/global/security/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.addAllowedOriginPattern("*"); // 모든 도메인 허용
+		configuration.addAllowedOriginPattern("https://localhost:3000");
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
 		configuration.setAllowedHeaders(Collections.singletonList("*")); // 모든 헤더 허용
 		configuration.setAllowCredentials(true); // 인증 정보를 포함한 요청 허용


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
```
		configuration.addAllowedOriginPattern("https://localhost:3000");
```
## 📝 참고사항
-

## 📚 기타
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened CORS settings to allow requests only from https://localhost:3000, blocking access from other origins.
  * Ensures consistent, secure browser behavior; no impact when using the allowed origin.
  * If you previously called the API from different hosts, those requests will now be blocked by the browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->