### PR TITLE
Fix: 런닝 시작 시 내부 서버 에러 발생 문제 수정

### DIFF
--- a/src/main/java/com/runky/notification/domain/push/DeviceTokenService.java
+++ b/src/main/java/com/runky/notification/domain/push/DeviceTokenService.java
@@ -50,6 +50,9 @@ public class DeviceTokenService {
 
 	@Transactional(readOnly = true)
 	public DeviceTokenInfo.ActiveTokens getActiveTokens(PushCommand.DeviceToken.Gets command) {
+		if (command.memberIds().isEmpty()) {
+			throw new GlobalException(NotificationErrorCode.EMTPY_TOKEN_OWNER_IDS);
+		}
 		return new DeviceTokenInfo.ActiveTokens(deviceTokenRepository.findActiveTokensByMemberIds(command.memberIds()));
 	}
 

--- a/src/main/java/com/runky/notification/error/NotificationErrorCode.java
+++ b/src/main/java/com/runky/notification/error/NotificationErrorCode.java
@@ -15,6 +15,7 @@ public enum NotificationErrorCode implements ErrorCode {
 	NOT_FOUND_DEVICE_TOKEN(HttpStatus.NOT_FOUND, "NDT101", "디바이스 토큰을 찾을 수 없습니다."),
 	NOT_EXIST_TO_DELETE_DEVICE_TOKEN(HttpStatus.NOT_FOUND, "NDT102", "삭제할 디바이스 토큰이 존재하지 않습니다."),
 	ALREADY_REGISTERED_DEVICE_TOKEN(HttpStatus.CONFLICT, "NDT103", "이미 존재하는 디바이스 토큰 입니다."),
+	EMTPY_TOKEN_OWNER_IDS(HttpStatus.INTERNAL_SERVER_ERROR, "NDT104", "디바이스 토큰을 조회할 멤버 아이디들이 비어있습니다"),
 	/* NDT2xx: DeviceToken  저장/포맷 */
 	DUPLICATE_UNIQUE_KEY_DEVICE_TOKEN(HttpStatus.CONFLICT, "NDT201", "같은 디바이스 토큰을 중복 저장할 수 없습니다."),
 

--- a/src/main/java/com/runky/running/application/RunningFacade.java
+++ b/src/main/java/com/runky/running/application/RunningFacade.java
@@ -32,6 +32,10 @@ public class RunningFacade {
 		RunningInfo.Start info = runningService.start(criteria.toCommand());
 		List<Long> receiverIds = crewService.getAllCrewMembersOfUser(criteria.runnerId());
 
+		if (receiverIds.isEmpty()) {
+			return RunningResult.Start.from(info);
+		}
+		
 		var memberFindCmd = new MemberCommand.Find(criteria.runnerId());
 		String runnerNickname = memberService.getMember(memberFindCmd).getNickname().value();
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- facade에서 크루 멤버들 알림 발송시, 디바이스 토큰 조회할때 크루 멤버가 없어서 빈 Id보내면 JPA DAO에서 예외발생 문제 해결

## 📝 참고사항
-

## 📚 기타
- 
