### PR TITLE
refactor: 프론트 배포 도메인 cors 적용

### DIFF
--- a/src/main/java/com/runky/global/security/SecurityConfig.java
+++ b/src/main/java/com/runky/global/security/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOriginPatterns(Arrays.asList("https://localhost:3000", "http://localhost:3000"));
+		configuration.setAllowedOriginPatterns(Arrays.asList("https://web.runky.store", "http://web.runky.store"));
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
 		configuration.setAllowedHeaders(Collections.singletonList("*")); // 모든 헤더 허용
 		configuration.setAllowCredentials(true); // 인증 정보를 포함한 요청 허용

--- a/src/main/java/com/runky/running/config/WebSocketConfig.java
+++ b/src/main/java/com/runky/running/config/WebSocketConfig.java
@@ -29,7 +29,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		registry
 			.addEndpoint("/ws")
 			.addInterceptors(jwtHandshakeInterceptor)
-			.setAllowedOriginPatterns("http://localhost:3000", "https://localhost:3000")
+			.setAllowedOriginPatterns("https://web.runky.store", "http://web.runky.store")
 			.withSockJS();
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved CORS errors by allowing requests from web.runky.store for API endpoints.
  * Fixed WebSocket connection issues by permitting web.runky.store during handshake.

* **Chores**
  * Aligned CORS policies with the production domain for both REST and WebSocket services, removing localhost allowances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->