### PR TITLE
chore: 서버 timezone 설정 추가

### DIFF
--- a/docker/server-compose.yml
+++ b/docker/server-compose.yml
@@ -6,6 +6,7 @@ services:
       - "80:8080"
     environment:
       - TZ=Asia/Seoul
+      - JAVA_TOOL_OPTIONS=-Duser.timezone=Asia/Seoul
     env_file:
       - .env
     restart: always


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
-

## 📝 참고사항
-

## 📚 기타
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured server runtime uses Asia/Seoul as the default timezone, aligning timestamps, logs, and time-sensitive behavior with the expected locale.

* **Chores**
  * Updated container startup configuration to set the JVM timezone. No application code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->