### PR TITLE
feat(Member): 회원탈퇴 api 구현

### DIFF
--- a/src/main/java/com/runky/auth/application/AuthFacade.java
+++ b/src/main/java/com/runky/auth/application/AuthFacade.java
@@ -1,11 +1,5 @@
 package com.runky.auth.application;
 
-import com.runky.crew.domain.CrewCommand;
-import com.runky.crew.domain.CrewService;
-import com.runky.goal.domain.GoalCommand;
-import com.runky.goal.domain.GoalService;
-import com.runky.reward.domain.RewardCommand;
-import com.runky.reward.domain.RewardService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,10 +10,16 @@ import com.runky.auth.domain.port.TokenDecoder;
 import com.runky.auth.domain.signup.SignupTokenService;
 import com.runky.auth.domain.vo.OAuthUserInfo;
 import com.runky.auth.domain.vo.RefreshTokenClaims;
+import com.runky.crew.domain.CrewCommand;
+import com.runky.crew.domain.CrewService;
+import com.runky.goal.domain.GoalCommand;
+import com.runky.goal.domain.GoalService;
 import com.runky.member.domain.MemberCommand;
 import com.runky.member.domain.dto.MemberInfo;
 import com.runky.member.domain.service.MemberReader;
 import com.runky.member.domain.service.MemberRegistrar;
+import com.runky.reward.domain.RewardCommand;
+import com.runky.reward.domain.RewardService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -36,11 +36,11 @@ public class AuthFacade {
 	private final TokenDecoder tokenDecoder;
 	private final AuthTokenService authTokenService;
 
-    private final RewardService rewardService;
-    private final GoalService goalService;
-    private final CrewService crewService;
+	private final RewardService rewardService;
+	private final GoalService goalService;
+	private final CrewService crewService;
 
-    /**
+	/**
 	 * 1) code → accessToken → providerId 조회
 	 * 2) 기존 회원이면 즉시 토큰 발급
 	 * 3) 신규면 signupToken 발급
@@ -77,9 +77,9 @@ public class AuthFacade {
 			));
 		signupTokenService.delete(signupToken);
 
-        rewardService.init(new RewardCommand.Init(saved.id()));
-        goalService.init(new GoalCommand.Init(saved.id()));
-        crewService.init(new CrewCommand.Init(saved.id()));
+		rewardService.init(new RewardCommand.Init(saved.id()));
+		goalService.init(new GoalCommand.Init(saved.id()));
+		crewService.init(new CrewCommand.Init(saved.id()));
 
 		AuthInfo.TokenPair pair = authTokenService.issue(saved.id(), saved.role().name());
 		return new AuthResult.SigninComplete(pair.accessToken(), pair.refreshToken());
@@ -96,5 +96,9 @@ public class AuthFacade {
 	public void logoutByRefresh(String refreshToken) {
 		RefreshTokenClaims decoded = tokenDecoder.decodeRefresh(refreshToken);
 		authTokenService.delete(decoded.memberId());
+	}
+
+	public void deleteAccountByRefresh(final String refreshToken) {
+
 	}
 }

--- a/src/main/java/com/runky/member/api/MemberApiSpec.java
+++ b/src/main/java/com/runky/member/api/MemberApiSpec.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Tag(name = "Member API", description = "Runky Member API입니다.")
 public interface MemberApiSpec {
@@ -44,5 +45,14 @@ public interface MemberApiSpec {
 	ApiResponse<MemberResponse.Badge> getMemberBadge(
 		@Parameter(hidden = true) MemberPrincipal requester,
 		Long targetId
+	);
+
+	@Operation(
+		summary = "회원 탈퇴",
+		description = "유저의 리프레쉬토큰,유저의 회원정보를 영구 삭제합니다."
+	)
+	ApiResponse<Void> deleteAccount(
+		@Parameter(hidden = true) MemberPrincipal requester,
+		HttpServletResponse response
 	);
 }

--- a/src/main/java/com/runky/member/application/MemberFacade.java
+++ b/src/main/java/com/runky/member/application/MemberFacade.java
@@ -1,36 +1,50 @@
 package com.runky.member.application;
 
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.runky.auth.domain.AuthTokenService;
 import com.runky.member.domain.Member;
 import com.runky.member.domain.MemberCommand;
 import com.runky.member.domain.MemberService;
 import com.runky.reward.domain.Badge;
 import com.runky.reward.domain.RewardCommand;
 import com.runky.reward.domain.RewardService;
+
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class MemberFacade {
 
-    private final MemberService memberService;
-    private final RewardService rewardService;
+	private final AuthTokenService authTokenService;
+	private final MemberService memberService;
+	private final RewardService rewardService;
 
-    public MemberResult.WithBadge getMember(MemberCriteria.Get criteria) {
-        Member member = memberService.getMember(new MemberCommand.Find(criteria.memberId()));
-        Badge badge = rewardService.getBadge(new RewardCommand.Find(member.getBadgeId()));
-        return MemberResult.WithBadge.of(member, badge);
-    }
+	@Transactional(readOnly = true)
+	public MemberResult.WithBadge getMember(MemberCriteria.Get criteria) {
+		Member member = memberService.getMember(new MemberCommand.Find(criteria.memberId()));
+		Badge badge = rewardService.getBadge(new RewardCommand.Find(member.getBadgeId()));
+		return MemberResult.WithBadge.of(member, badge);
+	}
 
-    public MemberResult changeNickname(MemberCriteria.ChangeNickname criteria) {
-        Member member = memberService.changeNickname(criteria.toCommand());
-        return MemberResult.from(member);
-    }
+	@Transactional
+	public MemberResult changeNickname(MemberCriteria.ChangeNickname criteria) {
+		Member member = memberService.changeNickname(criteria.toCommand());
+		return MemberResult.from(member);
+	}
 
-    public MemberResult.WithBadge changeBadge(MemberCriteria.ChangeBadge criteria) {
-        Badge badge = rewardService.getMemberBadge(
-                new RewardCommand.FindMemberBadge(criteria.memberId(), criteria.badgeId()));
-        Member member = memberService.changeBadge(new MemberCommand.ChangeBadge(criteria.memberId(), badge.getId()));
-        return MemberResult.WithBadge.of(member, badge);
-    }
+	@Transactional
+	public MemberResult.WithBadge changeBadge(MemberCriteria.ChangeBadge criteria) {
+		Badge badge = rewardService.getMemberBadge(
+			new RewardCommand.FindMemberBadge(criteria.memberId(), criteria.badgeId()));
+		Member member = memberService.changeBadge(new MemberCommand.ChangeBadge(criteria.memberId(), badge.getId()));
+		return MemberResult.WithBadge.of(member, badge);
+	}
+
+	@Transactional
+	public void deleteAccount(Long memberId) {
+		authTokenService.delete(memberId);
+		memberService.delete(new MemberCommand.DeleteMember(memberId));
+	}
 }

--- a/src/main/java/com/runky/member/domain/MemberCommand.java
+++ b/src/main/java/com/runky/member/domain/MemberCommand.java
@@ -30,4 +30,9 @@ public final class MemberCommand {
 		Set<Long> memberIds
 	) {
 	}
+
+	public record DeleteMember(
+		Long memberId
+	) {
+	}
 }

--- a/src/main/java/com/runky/member/domain/MemberRepository.java
+++ b/src/main/java/com/runky/member/domain/MemberRepository.java
@@ -11,7 +11,9 @@ public interface MemberRepository {
 
 	Member save(Member member);
 
-    Optional<Member> findById(Long id);
+	Optional<Member> findById(Long id);
 
-    List<Member> findMembers(Set<Long> ids);
+	List<Member> findMembers(Set<Long> ids);
+
+	void delete(Long id);
 }

--- a/src/main/java/com/runky/member/domain/MemberService.java
+++ b/src/main/java/com/runky/member/domain/MemberService.java
@@ -1,47 +1,55 @@
 package com.runky.member.domain;
 
-import com.runky.global.error.GlobalException;
-import com.runky.member.error.MemberErrorCode;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.runky.global.error.GlobalException;
+import com.runky.member.error.MemberErrorCode;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
-    private final MemberRepository memberRepository;
+	private final MemberRepository memberRepository;
 
-    @Transactional(readOnly = true)
-    public Member getMember(MemberCommand.Find command) {
-        return memberRepository.findById(command.memberId())
-                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
-    }
+	@Transactional(readOnly = true)
+	public Member getMember(MemberCommand.Find command) {
+		return memberRepository.findById(command.memberId())
+			.orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
+	}
 
-    public Member changeNickname(MemberCommand.ChangeNickname command) {
-        Member member = memberRepository.findById(command.memberId())
-                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
-        member.changeNickname(command.nickname());
-        try {
-            memberRepository.save(member);
-        } catch (DataIntegrityViolationException e) {
-            throw new GlobalException(MemberErrorCode.DUPLICATE_NICKNAME);
-        }
-        return member;
-    }
+	public Member changeNickname(MemberCommand.ChangeNickname command) {
+		Member member = memberRepository.findById(command.memberId())
+			.orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
+		member.changeNickname(command.nickname());
+		try {
+			memberRepository.save(member);
+		} catch (DataIntegrityViolationException e) {
+			throw new GlobalException(MemberErrorCode.DUPLICATE_NICKNAME);
+		}
+		return member;
+	}
 
-    @Transactional
-    public Member changeBadge(MemberCommand.ChangeBadge command) {
-        Member member = memberRepository.findById(command.memberId())
-                .orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
-        member.changeBadge(command.badgeId());
-        return member;
-    }
+	@Transactional
+	public Member changeBadge(MemberCommand.ChangeBadge command) {
+		Member member = memberRepository.findById(command.memberId())
+			.orElseThrow(() -> new GlobalException(MemberErrorCode.MEMBER_NOT_FOUND));
+		member.changeBadge(command.badgeId());
+		return member;
+	}
 
-    @Transactional(readOnly = true)
-    public List<Member> getMembers(MemberCommand.GetMembers command) {
-        return memberRepository.findMembers(command.memberIds());
-    }
+	@Transactional(readOnly = true)
+	public List<Member> getMembers(MemberCommand.GetMembers command) {
+		return memberRepository.findMembers(command.memberIds());
+	}
+
+	@Transactional
+	public void delete(MemberCommand.DeleteMember command) {
+		memberRepository.delete(command.memberId());
+	}
 }

--- a/src/main/java/com/runky/member/infrastructure/persistence/MemberRepositoryImpl.java
+++ b/src/main/java/com/runky/member/infrastructure/persistence/MemberRepositoryImpl.java
@@ -2,8 +2,8 @@ package com.runky.member.infrastructure.persistence;
 
 import java.util.List;
 import java.util.Optional;
-
 import java.util.Set;
+
 import org.springframework.stereotype.Repository;
 
 import com.runky.member.domain.Member;
@@ -32,13 +32,18 @@ public class MemberRepositoryImpl implements MemberRepository {
 		return jpaMemberRepository.save(member);
 	}
 
-    @Override
-    public Optional<Member> findById(Long id) {
-        return jpaMemberRepository.findById(id);
-    }
+	@Override
+	public Optional<Member> findById(Long id) {
+		return jpaMemberRepository.findById(id);
+	}
 
-    @Override
-    public List<Member> findMembers(Set<Long> ids) {
-        return jpaMemberRepository.findByIdIn(ids);
-    }
+	@Override
+	public List<Member> findMembers(Set<Long> ids) {
+		return jpaMemberRepository.findByIdIn(ids);
+	}
+
+	@Override
+	public void delete(Long id) {
+		jpaMemberRepository.deleteById(id);
+	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #175

## 📌 작업 내용 및 특이사항
- 회원탈퇴 api 구현

## 📝 참고사항
-

## 📚 기타
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now permanently delete your account. When you do, your data is removed and you’re automatically signed out (relevant cookies are cleared).
  * Available to authenticated users via the account deletion endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->