### PR TITLE
feat(Running): WebSocket 메세지 파이프라인 예외 처리 핸들러 기능 추가

### DIFF
--- a/src/main/java/com/runky/running/infra/websocket/WebSocketConfig.java
+++ b/src/main/java/com/runky/running/infra/websocket/WebSocketConfig.java
@@ -7,6 +7,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import com.runky.running.infra.websocket.exception.StompErrorFrameHandler;
 import com.runky.running.infra.websocket.handshake.CookieAuthHandshakeInterceptor;
 import com.runky.running.infra.websocket.inbound.InboundChannelLogger;
 import com.runky.running.infra.websocket.inbound.JwtChannelInterceptor;
@@ -22,6 +23,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	private final InboundChannelLogger inboundChannelLogger;
 	private final OutboundChannelLogger outboundChannelLogger;
 	private final CookieAuthHandshakeInterceptor cookieAuthHandshakeInterceptor;
+
+	private final StompErrorFrameHandler stompErrorFrameHandler;
 
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -41,6 +44,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 				"https://localhost:*", "http://localhost:*",
 				"null"
 			);
+		registry.setErrorHandler(stompErrorFrameHandler);
+
 	}
 
 	@Override

--- a/src/main/java/com/runky/running/infra/websocket/exception/StompErrorFrameHandler.java
+++ b/src/main/java/com/runky/running/infra/websocket/exception/StompErrorFrameHandler.java
@@ -1,0 +1,119 @@
+package com.runky.running.infra.websocket.exception;
+
+import static org.springframework.util.MimeTypeUtils.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompConversionException;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.runky.global.response.ApiResponse;
+import com.runky.running.error.RunningErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StompErrorFrameHandler extends StompSubProtocolErrorHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public Message<byte[]> handleClientMessageProcessingError(@Nullable Message<byte[]> clientMessage, Throwable ex) {
+		Throwable cause = rootCause(ex);
+
+		RunningErrorCode code = mapToErrorCode(cause);
+		String reason = resolveReason(cause, code);
+
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+		accessor.setLeaveMutable(true);
+		accessor.setContentType(APPLICATION_JSON);
+		accessor.setMessage(code.name());
+		copyReceiptId(clientMessage, accessor);
+
+		byte[] payload = toJson(ApiResponse.error(code, reason));
+		return MessageBuilder.createMessage(payload, accessor.getMessageHeaders());
+	}
+
+	private void copyReceiptId(@Nullable Message<byte[]> clientMessage, StompHeaderAccessor errorHeaders) {
+		if (clientMessage == null)
+			return;
+		StompHeaderAccessor clientHeaders = StompHeaderAccessor.wrap(clientMessage);
+		String receiptId = clientHeaders.getReceipt();
+		if (receiptId != null) {
+			errorHeaders.setReceiptId(receiptId);
+		}
+	}
+
+	private RunningErrorCode mapToErrorCode(Throwable t) {
+		// 1) 인증/세션
+		if (t instanceof AuthenticationException
+			|| t instanceof IllegalStateException
+			/*|| t instanceof ExpiredTokenException
+			|| t instanceof InvalidTokenException*/) {
+			return RunningErrorCode.UNAUTHORIZED_SESSION;
+		}
+
+		// 2) STOMP/JSON 변환 실패
+		if (t instanceof StompConversionException
+			|| t instanceof MessageConversionException
+			|| t instanceof JsonProcessingException) {
+			return RunningErrorCode.PAYLOAD_INVALID;
+		}
+
+		// 3) 라우팅/전달 실패
+		if (t instanceof MessageDeliveryException) {
+			return RunningErrorCode.EVENT_PUBLISH_FAILED;
+		}
+
+		// 4) 프로토콜 위반/필수 헤더 누락(일부 IllegalArgumentException)
+		if (t instanceof IllegalArgumentException) {
+			return RunningErrorCode.PAYLOAD_INVALID;
+		}
+
+		// 5) 그 외
+		return RunningErrorCode.INTERNAL_ERROR;
+	}
+
+	private String resolveReason(Throwable t, RunningErrorCode code) {
+		String msg = t.getMessage();
+		if (msg == null || msg.isBlank()) {
+			return code.getMessage();
+		}
+		// 메시지가 과하게 길면 잘라서 보냄
+		if (msg.length() > 512) {
+			return msg.substring(0, 512) + "…";
+		}
+		return msg;
+	}
+
+	private byte[] toJson(ApiResponse<?> body) {
+		try {
+			return objectMapper.writeValueAsString(body).getBytes(StandardCharsets.UTF_8);
+
+		} catch (JsonProcessingException e) {
+			// 직렬화 실패 시 텍스트로 폴백
+			String fallback = "{\"success\":false,\"code\":\"INTERNAL_ERROR\",\"message\":\"serialization failed\"}";
+			return fallback.getBytes(StandardCharsets.UTF_8);
+		}
+	}
+
+	private Throwable rootCause(Throwable t) {
+		Throwable cur = t;
+		while (cur.getCause() != null && cur.getCause() != cur) {
+			cur = cur.getCause();
+		}
+		return cur;
+	}
+}

--- a/src/test/java/com/runky/running/infra/websocket/exception/StompErrorFrameHandlerTest.java
+++ b/src/test/java/com/runky/running/infra/websocket/exception/StompErrorFrameHandlerTest.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.runky.running.error.RunningErrorCode;
 
-class StompErrorFrameHandlerTest_MinimalJsonNode {
+class StompErrorFrameHandlerTest {
 
 	private final ObjectMapper om = new ObjectMapper();
 	private final StompErrorFrameHandler handler = new StompErrorFrameHandler(om);
@@ -74,5 +74,5 @@ class StompErrorFrameHandlerTest_MinimalJsonNode {
 		// then 2) 바디: JsonNode로 code만 검증
 		JsonNode node = om.readTree(errorMsg.getPayload());
 		assertThat(node.get("code").asText()).isEqualTo(expected.getCode());
-	}트
+	}
 }

--- a/src/test/java/com/runky/running/infra/websocket/exception/StompErrorFrameHandlerTest.java
+++ b/src/test/java/com/runky/running/infra/websocket/exception/StompErrorFrameHandlerTest.java
@@ -1,0 +1,78 @@
+package com.runky.running.infra.websocket.exception;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompConversionException;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.runky.running.error.RunningErrorCode;
+
+class StompErrorFrameHandlerTest_MinimalJsonNode {
+
+	private final ObjectMapper om = new ObjectMapper();
+	private final StompErrorFrameHandler handler = new StompErrorFrameHandler(om);
+
+	private static Message<byte[]> dummyClientMessage() {
+		StompHeaderAccessor acc = StompHeaderAccessor.create(StompCommand.SEND);
+		acc.setSessionId("sess-1");
+		return MessageBuilder.createMessage("x".getBytes(StandardCharsets.UTF_8), acc.getMessageHeaders());
+	}
+
+	private static Stream<Arguments> cases() {
+		return Stream.of(
+			Arguments.of(new AuthenticationCredentialsNotFoundException("no token"),
+				RunningErrorCode.UNAUTHORIZED_SESSION),
+
+			Arguments.of(new StompConversionException("bad stomp"),
+				RunningErrorCode.PAYLOAD_INVALID),
+
+			Arguments.of(new MessageConversionException("bad json"),
+				RunningErrorCode.PAYLOAD_INVALID),
+
+			Arguments.of(new JsonProcessingException("bad json") {
+						 },
+				RunningErrorCode.PAYLOAD_INVALID),
+
+			Arguments.of(new MessageDeliveryException("no subscribers"),
+				RunningErrorCode.EVENT_PUBLISH_FAILED),
+
+			Arguments.of(new IllegalArgumentException("bad header"),
+				RunningErrorCode.PAYLOAD_INVALID),
+
+			Arguments.of(new RuntimeException("boom"),
+				RunningErrorCode.INTERNAL_ERROR)
+		);
+	}
+
+	@ParameterizedTest(name = "{index} ⇒ {0} → {1}")
+	@MethodSource("cases")
+	@DisplayName("컨트롤러 이전 파이프라인에서 발생한 예외는 STOMP ERROR 헤더 + ApiResponse.code로 표준화된다")
+	void 예외가_ERROR프레임으로_매핑되고_code만_검증한다(Throwable ex, RunningErrorCode expected) throws Exception {
+		// when
+		Message<byte[]> errorMsg = handler.handleClientMessageProcessingError(dummyClientMessage(), ex);
+
+		// then 1) 헤더: STOMP ERROR 프레임인지
+		StompHeaderAccessor h = StompHeaderAccessor.wrap(errorMsg);
+		assertThat(h.getCommand()).isEqualTo(StompCommand.ERROR);
+
+		// then 2) 바디: JsonNode로 code만 검증
+		JsonNode node = om.readTree(errorMsg.getPayload());
+		assertThat(node.get("code").asText()).isEqualTo(expected.getCode());
+	}트
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #

## 📌 작업 내용 및 특이사항
- WebSocket 메세지 파이프라인 예외 처리 핸들러 기능을 추가합니다.
- [x] 핸들러 구현
- [x] 핸들러 등록
- [x] 핸들러 단위 테스트  

## 📝 참고사항
-

## 📚 기타
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized STOMP/WebSocket error responses: clients now receive structured JSON error payloads with clear error codes and concise reasons.
  * Error frames preserve the original receipt header for easier correlation and retries.
  * Consistent mapping of common failures (authentication, invalid payloads, publish failures) to clear, client-visible errors.
  * WebSocket error handling is now integrated into the STOMP endpoint configuration.

* **Tests**
  * Added parameterized tests verifying STOMP ERROR frames and the presence of expected error codes in JSON payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->